### PR TITLE
Copy behaviour attributes

### DIFF
--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -88,8 +88,10 @@ defmodule Mimic.Module do
 
   defp create_mock(module) do
     mimic_info = module_mimic_info()
+    mimic_behaviours = generate_mimic_behaviours(module)
     mimic_functions = generate_mimic_functions(module)
-    Module.create(module, [mimic_info | mimic_functions], Macro.Env.location(__ENV__))
+    quoted = [mimic_info | [mimic_behaviours ++ mimic_functions]]
+    Module.create(module, quoted, Macro.Env.location(__ENV__))
     module
   end
 
@@ -114,5 +116,16 @@ defmodule Mimic.Module do
         end
       end
     end
+  end
+
+  defp generate_mimic_behaviours(module) do
+    module.module_info(:attributes)
+    |> Keyword.get_values(:behaviour)
+    |> List.flatten()
+    |> Enum.map(fn behaviour ->
+      quote do
+        @behaviour unquote(behaviour)
+      end
+    end)
   end
 end

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -727,4 +727,16 @@ defmodule Mimic.Test do
       |> Task.await()
     end
   end
+
+  describe "behaviours" do
+    test "copies behaviour attributes" do
+      behaviours =
+        Calculator.module_info(:attributes)
+        |> Keyword.get_values(:behaviour)
+        |> List.flatten()
+
+      assert AddAdapter in behaviours
+      assert MultAdapter in behaviours
+    end
+  end
 end

--- a/test/support/test_modules.ex
+++ b/test/support/test_modules.ex
@@ -1,5 +1,17 @@
+defmodule AddAdapter do
+  @moduledoc false
+  @callback add(number(), number()) :: number()
+end
+
+defmodule MultAdapter do
+  @moduledoc false
+  @callback mult(number(), number()) :: number()
+end
+
 defmodule Calculator do
   @moduledoc false
+  @behaviour AddAdapter
+  @behaviour MultAdapter
   def add(x, y), do: x + y
   def mult(x, y), do: x * y
 end


### PR DESCRIPTION
When using with `mox`, the `Mox.stub_with/2` checks the module behaviours and raises the error if the module was copied by `mimic`.