### PR TITLE
delete modules_beam in state after reset

### DIFF
--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -314,7 +314,9 @@ defmodule Mimic.Server do
       _ -> Mimic.Module.clear!(module)
     end
 
-    {:reply, :ok, state}
+    modules_beam = Map.delete(state.modules_beam, module)
+
+    {:reply, :ok, %{state | modules_beam: modules_beam}}
   end
 
   defp apply_call_to_expectations(


### PR DESCRIPTION
Otherwise, in umbrella projects, `reset` will be called again and an error will be raised then like:
```
08:38:54.767 module=gen_server function=error_info/7 line=889 [error] GenServer Mimic.Server terminating
** (MatchError) no match of right hand side value: {:error, {:not_cover_compiled, Foo.Mimic.Original.Module}}
    (mimic) lib/mimic/cover.ex:32: Mimic.Cover.export_coverdata!/1
    (mimic) lib/mimic/cover.ex:19: Mimic.Cover.replace_coverdata!/3
    (mimic) lib/mimic/server.ex:314: Mimic.Server.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.916.0>): {:reset, Foo}
```