### PR TITLE
Adds `Mimic.mode/0` for exposing the current mode

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -419,7 +419,7 @@ defmodule Mimic do
   end
 
   @doc "Returns the current mode (`:global` or `:private`)"
-  @spec mode() :: atom()
+  @spec mode() :: :private | :global
   def mode do
     Server.get_mode()
     |> validate_server_response("Couldn't get the current mode.")

--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -418,6 +418,13 @@ defmodule Mimic do
     :ok
   end
 
+  @doc "Returns the current mode (`:global` or `:private`)"
+  @spec mode() :: atom()
+  def mode do
+    Server.get_mode()
+    |> validate_server_response("Couldn't get the current mode.")
+  end
+
   defp raise_if_not_copied!(module) do
     unless function_exported?(module, :__mimic_info__, 0) do
       raise ArgumentError,

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -50,6 +50,10 @@ defmodule Mimic.Server do
     GenServer.call(__MODULE__, :set_private_mode)
   end
 
+  def get_mode do
+    GenServer.call(__MODULE__, :get_mode)
+  end
+
   def exit(pid) do
     GenServer.cast(__MODULE__, {:exit, pid})
   end
@@ -263,6 +267,10 @@ defmodule Mimic.Server do
 
   def handle_call(:set_private_mode, _from, state) do
     {:reply, :ok, do_set_private_mode(state)}
+  end
+
+  def handle_call(:get_mode, _from, state) do
+    {:reply, {:ok, state.mode}, state}
   end
 
   def handle_call({:allow, module, owner_pid, allowed_pid}, _from, state = %State{mode: :private}) do

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -728,6 +728,22 @@ defmodule Mimic.Test do
     end
   end
 
+  describe "mode/0 global mode" do
+    setup :set_mimic_global
+
+    test "returns :global" do
+      assert Mimic.mode() == :global
+    end
+  end
+
+  describe "mode/0 private mode" do
+    setup :set_mimic_private
+
+    test "returns :private" do
+      assert Mimic.mode() == :private
+    end
+  end
+
   describe "behaviours" do
     test "copies behaviour attributes" do
       behaviours =


### PR DESCRIPTION
Related to https://github.com/edgurgel/mimic/issues/13, adds a `Mimic.mode/0` function for exposing the current mode.