### PR TITLE
Bump version in readme to "~> 1.4"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Just add `mimic` to your list of dependencies in mix.exs:
 ```elixir
 def deps do
   [
-    {:mimic, "~> 1.3", only: :test}
+    {:mimic, "~> 1.4", only: :test}
   ]
 end
 ```


### PR DESCRIPTION
Bumping the version in the README to 1.4 to be in sync with the latest tag for ~~easy~~ lazy copy-pasting into `mix.exs` :)