### PR TITLE
updating ensure_compiled call

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -335,15 +335,16 @@ defmodule Mimic do
   """
   @spec copy(module()) :: :ok
   def copy(module) do
-    if not Code.ensure_compiled?(module) do
-      raise ArgumentError,
-            "Module #{inspect(module)} is not available"
+    case Code.ensure_compiled(module) do
+      {:error, _} ->
+        raise ArgumentError,
+              "Module #{inspect(module)} is not available"
+      {:module, module} ->
+        Mimic.Module.replace!(module)
+        ExUnit.after_suite(fn _ -> Server.reset(module) end)
+
+        :ok
     end
-
-    Mimic.Module.replace!(module)
-    ExUnit.after_suite(fn _ -> Server.reset(module) end)
-
-    :ok
   end
 
   @doc """

--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -339,6 +339,7 @@ defmodule Mimic do
       {:error, _} ->
         raise ArgumentError,
               "Module #{inspect(module)} is not available"
+
       {:module, module} ->
         Mimic.Module.replace!(module)
         ExUnit.after_suite(fn _ -> Server.reset(module) end)


### PR DESCRIPTION
This PR updates the call from `Code.ensure_compiled?/1` to `Code.ensure_compiled/1` to address deprecation warnings in newer versions of Elixir (1.11+). This change should be safe as the replacement function has been included in the Code module since at least the minimum supported version by Mimic.

Thanks!