### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,9 +1,6 @@
+# Used by "mix format"
 [
-  inputs: [
-    "lib/**/*.{ex,exs}",
-    "test/**/*.{ex,exs}",
-    "mix.exs"
-  ],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: [allow: :*, expect: :*],
   export: [
     locals_without_parens: [allow: :*, expect: :*]

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,26 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
 
 # If the VM crashes, it generates a dump, let's ignore it too.
 erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore package tarball (built via "mix hex.build").
+mimic-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Mimic [![Build Status](https://github.com/edgurgel/mimic/workflows/CI/badge.svg?branch=master)](https://github.com/edgurgel/mimic/actions?query=workflow%3ACI) [![Hex pm](http://img.shields.io/hexpm/v/mimic.svg?style=flat)](https://hex.pm/packages/mimic)
+# Mimic
 
+[![Build Status](https://github.com/edgurgel/mimic/workflows/CI/badge.svg?branch=master)](https://github.com/edgurgel/mimic/actions?query=workflow%3ACI)
+[![Module Version](https://img.shields.io/hexpm/v/mimic.svg)](https://hex.pm/packages/mimic)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/mimic/)
+[![Total Download](https://img.shields.io/hexpm/dt/mimic.svg)](https://hex.pm/packages/mimic)
+[![License](https://img.shields.io/hexpm/l/mimic.svg)](https://github.com/edgurgel/mimic/blob/master/LICENSE)
+[![Last Updated](https://img.shields.io/github/last-commit/edgurgel/mimic.svg)](https://github.com/edgurgel/mimic/commits/master)
 
-A sane way of using mocks in Elixir. It borrows a lot from both Meck & Mox! Thanks @eproxus & @josevalim
+A sane way of using mocks in Elixir. It borrows a lot from both Meck & Mox! Thanks [@eproxus](https://twitter.com/eproxus) & [@josevalim](https://twitter.com/josevalim).
 
 ## Installation
 
-Just add `mimic` to your list of dependencies in mix.exs:
+Just add `:mimic` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -215,3 +221,17 @@ There's a small fixed price to pay when mimic is used but it is unnoticeable for
 ## Acknowledgements
 
 Thanks to [@jamesotron](https://github.com/jamesotron) and [@alissonsales](http://github.com/alissonsales) for all the help! :tada:
+
+## Copyright and License
+
+Copyright (c) 2016 Eduardo Gurgel
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -1,6 +1,7 @@
 defmodule Mimic.Cover do
   @moduledoc """
-  Abuse cover private functions to move stuff around
+  Abuse cover private functions to move stuff around.
+
   Completely based on meck's solution:
   https://github.com/eproxus/meck/blob/2c7ba603416e95401500d7e116c5a829cb558665/src/meck_cover.erl#L67-L91
   """

--- a/lib/mimic/dsl.ex
+++ b/lib/mimic/dsl.ex
@@ -1,6 +1,6 @@
 defmodule Mimic.DSL do
   @moduledoc """
-  stubs and expectations can be expressed in a more natural way
+  Stubs and expectations can be expressed in a more natural way.
 
   ```elixir
   use Mimic.DSL
@@ -19,7 +19,8 @@ defmodule Mimic.DSL do
   end
   ```
 
-  Support for expecting multiple calls
+  Support for expecting multiple calls:
+
   ```elixir
   expect Calculator.add(x, y), num_calls: 2 do
     x + y

--- a/mix.exs
+++ b/mix.exs
@@ -1,20 +1,22 @@
 defmodule Mimic.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/edgurgel/mimic"
+  @version "1.5.0"
+
   def project do
     [
       app: :mimic,
-      version: "1.5.0",
+      version: @version,
       elixir: "~> 1.10",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       name: "Mimic",
-      description: "Mocks for Elixir functions",
       deps: deps(),
       package: package(),
-      test_coverage: [tool: Mimic.TestCover],
-      docs: [extras: ["README.md"], main: "readme"]
+      docs: docs(),
+      test_coverage: [tool: Mimic.TestCover]
     ]
   end
 
@@ -30,17 +32,33 @@ defmodule Mimic.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.19", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.0", only: :dev}
     ]
   end
 
   defp package do
-    %{
+    [
+      description: "Mocks for Elixir functions",
       files: ["lib", "LICENSE", "mix.exs", "README.md"],
-      licenses: ["Apache 2"],
+      licenses: ["Apache-2"],
       maintainers: ["Eduardo Gurgel"],
-      links: %{"GitHub" => "https://github.com/edgurgel/mimic"}
-    }
+      links: %{
+        "GitHub" => @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        LICENSE: [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      formatters: ["html"]
+    ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the main reference doc for this
Elixir library which leverage on latest features of ExDoc.