### PR TITLE
Change original module renaming to happen lazily

### DIFF
--- a/lib/mimic/application.ex
+++ b/lib/mimic/application.ex
@@ -5,7 +5,12 @@ defmodule Mimic.Application do
 
   def start(_, _) do
     Cover.export_private_functions()
-    children = [Server]
+
+    children = [
+      Server,
+      {DynamicSupervisor, strategy: :one_for_one, name: Mimic.Modules}
+    ]
+
     Supervisor.start_link(children, name: Mimic.Supervisor, strategy: :one_for_one)
   end
 end

--- a/lib/mimic/module_loader.ex
+++ b/lib/mimic/module_loader.ex
@@ -1,0 +1,34 @@
+defmodule Mimic.ModuleLoader do
+  @moduledoc false
+
+  use GenServer
+
+  defp name(module) do
+    "#{module}.Loader" |> String.to_atom()
+  end
+
+  def rename_module(module) do
+    GenServer.call(name(module), {:rename_module, module}, 60_000)
+  end
+
+  def start_link(module) do
+    GenServer.start_link(__MODULE__, [], name: name(module))
+  end
+
+  def init([]) do
+    {:ok, nil}
+  end
+
+  def handle_call({:rename_module, module}, _from, state) do
+    case Mimic.Server.fetch_beam_code(module) do
+      [{^module, beam_code, compiler_options}] ->
+        Mimic.Module.rename_module(module, beam_code, compiler_options)
+        Mimic.Server.delete_beam_code(module)
+
+      _ ->
+        :ok
+    end
+
+    {:reply, :ok, state}
+  end
+end


### PR DESCRIPTION
This PR makes the renaming of the original module to happen just when the original module has to be called. It changes `Mimic.copy` to do the minimum amount of work

It adds a little bit of contention as it has to check against an ETS table if the module has been compiled or not but its seems to be a good enough approach. We could explore other solutions down the line if needed.


Hopefully this is a good fix for https://github.com/edgurgel/mimic/issues/32



cc/ @calvin-kargo 