### PR TITLE
make `Mimic.Server.reset` timeout to infinity

### DIFF
--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -63,7 +63,7 @@ defmodule Mimic.Server do
   end
 
   def reset(module) do
-    GenServer.call(__MODULE__, {:reset, module})
+    GenServer.call(__MODULE__, {:reset, module}, :infinity)
   end
 
   def apply(module, fn_name, args) do


### PR DESCRIPTION
Make `Mimic.Server.reset` timeout to infinity. 

With many enough mocked module (~100), and on commodity hardware, having `Mimic.Server.reset` timeout at 5 second will crash `ExUnit.after_suite`, which result in `mix test` reported as failing even though all test passed. This is because Mimic.Server.reset is calling a single genserver and thus cause a bottleneck issue. 