### PR TITLE
Change original module renaming to happen lazily when coverage is not reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,13 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - otp: 24.3
+            elixir: 1.13.3
+            coverage: true
           - otp: 23.1.1
             elixir: 1.11.3
-            coverage: true
-          - otp: 23.0
-            elixir: 1.10.3
-          - otp: 22.3
-            elixir: 1.10.3
+          - otp: 24.3
+            elixir: 1.12.3
     env:
       MIX_ENV: test
     steps:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,0 @@
-use Mix.Config

--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -120,14 +120,11 @@ defmodule Mimic do
   @spec stub(module(), atom(), function()) :: module
   def stub(module, function_name, function) do
     arity = :erlang.fun_info(function)[:arity]
-    raise_if_not_copied!(module)
     raise_if_not_exported_function!(module, function_name, arity)
 
     module
     |> Server.stub(function_name, arity, function)
-    |> validate_server_response(
-      "Stub cannot be called by the current process. Only the global owner is allowed."
-    )
+    |> validate_server_response(:stub)
   end
 
   @doc """
@@ -153,13 +150,9 @@ defmodule Mimic do
   """
   @spec stub(module()) :: module()
   def stub(module) do
-    raise_if_not_copied!(module)
-
     module
     |> Server.stub()
-    |> validate_server_response(
-      "Stub cannot be called by the current process. Only the global owner is allowed."
-    )
+    |> validate_server_response(:stub)
   end
 
   @doc """
@@ -189,13 +182,9 @@ defmodule Mimic do
   """
   @spec stub_with(module(), module()) :: module()
   def stub_with(module, mocking_module) do
-    raise_if_not_copied!(module)
-
     module
     |> Server.stub_with(mocking_module)
-    |> validate_server_response(
-      "Stub cannot be called by the current process. Only the global owner is allowed."
-    )
+    |> validate_server_response(:stub)
   end
 
   @doc """
@@ -238,14 +227,11 @@ defmodule Mimic do
       when is_atom(module) and is_atom(fn_name) and is_integer(num_calls) and num_calls >= 1 and
              is_function(func) do
     arity = :erlang.fun_info(func)[:arity]
-    raise_if_not_copied!(module)
     raise_if_not_exported_function!(module, fn_name, arity)
 
     module
     |> Server.expect(fn_name, arity, num_calls, func)
-    |> validate_server_response(
-      "Expect cannot be called by the current process. Only the global owner is allowed."
-    )
+    |> validate_server_response(:expect)
   end
 
   @doc """
@@ -274,14 +260,11 @@ defmodule Mimic do
     arity = fun_info[:arity]
     module = fun_info[:module]
     fn_name = fun_info[:name]
-    raise_if_not_copied!(module)
     raise_if_not_exported_function!(module, fn_name, arity)
 
     module
     |> Server.expect(fn_name, arity, 0, function)
-    |> validate_server_response(
-      "Reject cannot be called by the current process. Only the global owner is allowed."
-    )
+    |> validate_server_response(:reject)
   end
 
   @doc """
@@ -308,15 +291,12 @@ defmodule Mimic do
   """
   @spec reject(module, atom, non_neg_integer) :: module
   def reject(module, function_name, arity) do
-    raise_if_not_copied!(module)
     raise_if_not_exported_function!(module, function_name, arity)
     func = :erlang.make_fun(module, function_name, arity)
 
     module
     |> Server.expect(function_name, arity, 0, func)
-    |> validate_server_response(
-      "Reject cannot be called by the current process. Only the global owner is allowed."
-    )
+    |> validate_server_response(:reject)
   end
 
   @doc """
@@ -358,7 +338,7 @@ defmodule Mimic do
   def allow(module, owner_pid, allowed_pid) do
     module
     |> Server.allow(owner_pid, allowed_pid)
-    |> validate_server_response("Allow must not be called when mode is global.")
+    |> validate_server_response(:allow)
   end
 
   @doc """
@@ -369,7 +349,7 @@ defmodule Mimic do
     * `module` - the name of the module to copy.
 
   """
-  @spec copy(module()) :: :ok
+  @spec copy(module()) :: :ok | no_return
   def copy(module) do
     case Code.ensure_compiled(module) do
       {:error, _} ->
@@ -377,8 +357,8 @@ defmodule Mimic do
               "Module #{inspect(module)} is not available"
 
       {:module, module} ->
-        Mimic.Module.replace!(module)
-        ExUnit.after_suite(fn _ -> Server.reset(module) end)
+        Mimic.Server.mark_to_copy(module)
+        ExUnit.after_suite(fn _ -> Mimic.Server.reset(module) end)
 
         :ok
     end
@@ -465,14 +445,6 @@ defmodule Mimic do
   @spec mode() :: :private | :global
   def mode do
     Server.get_mode()
-    |> validate_server_response("Couldn't get the current mode.")
-  end
-
-  defp raise_if_not_copied!(module) do
-    unless function_exported?(module, :__mimic_info__, 0) do
-      raise ArgumentError,
-            "Module #{inspect(module)} has not been copied.  See docs for Mimic.copy/1"
-    end
   end
 
   defp raise_if_not_exported_function!(module, fn_name, arity) do
@@ -481,8 +453,34 @@ defmodule Mimic do
     end
   end
 
-  defp validate_server_response({:ok, module}, _), do: module
+  defp validate_server_response({:ok, module}, _action), do: module
 
-  defp validate_server_response({:error, _}, error_message),
-    do: raise(ArgumentError, error_message)
+  defp validate_server_response({:error, :not_global_owner}, :reject) do
+    raise ArgumentError,
+          "Reject cannot be called by the current process. Only the global owner is allowed."
+  end
+
+  defp validate_server_response({:error, :not_global_owner}, :expect) do
+    raise ArgumentError,
+          "Expect cannot be called by the current process. Only the global owner is allowed."
+  end
+
+  defp validate_server_response({:error, :not_global_owner}, :stub) do
+    raise ArgumentError,
+          "Stub cannot be called by the current process. Only the global owner is allowed."
+  end
+
+  defp validate_server_response({:error, :not_global_owner}, :allow) do
+    raise ArgumentError,
+          "Allow cannot be called by the current process. Only the global owner is allowed."
+  end
+
+  defp validate_server_response({:error, :global}, :allow) do
+    raise ArgumentError, "Allow must not be called when mode is global."
+  end
+
+  defp validate_server_response({:error, {:module_not_copied, module}}, _action) do
+    raise ArgumentError,
+          "Module #{inspect(module)} has not been copied.  See docs for Mimic.copy/1"
+  end
 end

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -6,6 +6,11 @@ defmodule Mimic.Cover do
   https://github.com/eproxus/meck/blob/2c7ba603416e95401500d7e116c5a829cb558665/src/meck_cover.erl#L67-L91
   """
 
+  @spec enabled?(module) :: boolean
+  def enabled?(module) do
+    :cover.is_compiled(module) != false
+  end
+
   @doc false
   def export_private_functions do
     {_, binary, _} = :code.get_object_code(:cover)
@@ -15,22 +20,22 @@ defmodule Mimic.Cover do
   end
 
   @doc false
-  def replace_coverdata!(module, original_beam, original_coverdata) do
+  def replace_coverdata!(module, original_beam, original_coverdata_path) do
     original_module = Mimic.Module.original(module)
     path = export_coverdata!(original_module)
     rewrite_coverdata!(path, module)
     Mimic.Module.clear!(module)
     :cover.compile_beam(original_beam)
-    :ok = :cover.import(path)
-    :ok = :cover.import(original_coverdata)
+    :ok = :cover.import(String.to_charlist(path))
+    :ok = :cover.import(String.to_charlist(original_coverdata_path))
     File.rm(path)
-    File.rm(original_coverdata)
+    File.rm(original_coverdata_path)
   end
 
   @doc false
   def export_coverdata!(module) do
     path = Path.expand("#{module}-#{:os.getpid()}.coverdata", ".")
-    :ok = :cover.export(path, module)
+    :ok = :cover.export(String.to_charlist(path), module)
     path
   end
 

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -20,7 +20,7 @@ defmodule Mimic.Server do
     defstruct func: nil, num_applied_calls: 0, num_calls: nil
   end
 
-  @long_timeout 60_000
+  @long_timeout Application.compile_env(:mimic, :server_timeout, 60_000)
 
   @spec allow(module, pid, pid) :: {:ok, module} | {:error, :global}
   def allow(module, owner_pid, allowed_pid) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Mimic.Mixfile do
     [
       app: :mimic,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -593,7 +593,7 @@ defmodule Mimic.Test do
       assert_raise ArgumentError,
                    "Module String has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     reject(String, :split, fn x, y -> x + y end)
+                     reject(String, :split, 2)
                    end
     end
 
@@ -666,7 +666,7 @@ defmodule Mimic.Test do
       assert_raise ArgumentError,
                    "Module String has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     reject(String, :split, fn x, y -> x + y end)
+                     reject(String, :split, 2)
                    end
     end
 

--- a/test/support/test_cover.ex
+++ b/test/support/test_cover.ex
@@ -18,12 +18,14 @@ defmodule Mimic.TestCover do
     results =
       Enum.filter(results, fn
         {{Calculator, _, _}, _} -> true
+        {{NoStubs, _, _}, _} -> true
         _ -> false
       end)
 
     expected =
       {{Calculator, :add, 2}, 5} in results &&
-        {{Calculator, :mult, 2}, 5} in results
+        {{Calculator, :mult, 2}, 5} in results &&
+        {{NoStubs, :add, 2}, 2} in results
 
     unless expected do
       IO.puts("Cover results are incorrect!")

--- a/test/support/test_modules.ex
+++ b/test/support/test_modules.ex
@@ -33,3 +33,8 @@ defmodule Enumerator do
   @moduledoc false
   def to_list(x, y), do: Enum.to_list(x..y)
 end
+
+defmodule NoStubs do
+  @moduledoc false
+  def add(x, y), do: x + y
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,7 @@
+NoStubs.add(1, 2)
+NoStubs.add(3, 5)
 Calculator.add(2, 3)
+Mimic.copy(NoStubs)
 Mimic.copy(Calculator)
 Mimic.copy(Counter)
 ExUnit.start()


### PR DESCRIPTION
Second try on speeding up `Mimic.copy`!

If cover is not enabled Mimic will just mark the module to be copied instead of copying it. Once `stub`, `stub_with`,`expect` or `reject` is called the module is actually copied. This means that it will delay as much as possible.

When cover is enabled copying will happen as soon as `Mimic.copy`is called so that there is a clean point where the module is replaced and cover data is not lost.

It also changes the way that `reset` is handled so it runs things in parallel using Tasks. 

I think this has no drawbacks but might need some real tests with real projects out there. No breaking changes also :relieved: 

Hopefully this is a better fix to #32 