### PR TITLE
Clear beam modules on reset

### DIFF
--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -57,7 +57,7 @@ defmodule Mimic.Module do
 
       {:ok, module_name, binary, _warnings} ->
         load_binary(module_name, binary)
-        Binary
+        binary
     end
   end
 

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -441,6 +441,11 @@ defmodule Mimic.Server do
         state.reset_tasks
       end
 
+    # Clear the beam modules after starting the tasks (they read the state)
+    # This is important for umbrella apps since they'll run app after app
+    # and the modules that need to be covered will change between apps
+    state = %{state | modules_beam: Map.delete(state.modules_beam, module)}
+
     # All modules have been reset. We should await all tasks now
     if state.modules_to_be_copied == MapSet.new() do
       tasks


### PR DESCRIPTION
This may not be _correct_ but it does seem to fix the issue I reported in #40. However, I lack the proper understanding of `:cover` to really understand the differences between my scenario and the one reported in #12 that initially implemented this. In my case, `:cover.export()` was returning `:ok` still for these modules but the path they were being exported to belonged to the wrong app and the failure occurred later in `replace_coverdata!` when deleting the cover files. 

So either the correct fix is this and just don't report coverage for these modules or it is to fix the pathing for the other tasks in `replace_coverdata!`.

Happy to make changes or if you want to do something else instead feel free to just close. 😃

Edit: And the comment I left in there _seems_ right but again I don't have a strong understanding so it could just be totally wrong. Please double check this 😅