### PR TITLE
Lazy Load Cover private function hack

### DIFF
--- a/lib/mimic/application.ex
+++ b/lib/mimic/application.ex
@@ -4,7 +4,7 @@ defmodule Mimic.Application do
   @moduledoc false
 
   def start(_, _) do
-    Cover.setup_if_needed()
+    Cover.setup_if_enabled()
     children = [Server]
     Supervisor.start_link(children, name: Mimic.Supervisor, strategy: :one_for_one)
   end

--- a/lib/mimic/application.ex
+++ b/lib/mimic/application.ex
@@ -1,10 +1,9 @@
 defmodule Mimic.Application do
   use Application
-  alias Mimic.{Cover, Server}
+  alias Mimic.Server
   @moduledoc false
 
   def start(_, _) do
-    Cover.setup_if_enabled()
     children = [Server]
     Supervisor.start_link(children, name: Mimic.Supervisor, strategy: :one_for_one)
   end

--- a/lib/mimic/application.ex
+++ b/lib/mimic/application.ex
@@ -4,7 +4,7 @@ defmodule Mimic.Application do
   @moduledoc false
 
   def start(_, _) do
-    Cover.export_private_functions()
+    Cover.setup_if_needed()
     children = [Server]
     Supervisor.start_link(children, name: Mimic.Supervisor, strategy: :one_for_one)
   end

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -12,7 +12,7 @@ defmodule Mimic.Cover do
   end
 
   @doc false
-  def setup_if_needed do
+  def setup_if_enabled do
     if cover_enabled?(), do: export_private_functions()
     :ok
   end

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -12,7 +12,16 @@ defmodule Mimic.Cover do
   end
 
   @doc false
-  def private_functions_exported?() do
+  def ensure_private_functions_exported do
+    if private_functions_exported?() do
+      export_private_functions()
+    end
+
+    :ok
+  end
+
+  @doc false
+  def private_functions_exported? do
     function_exported?(:cover, :get_term, 1)
   end
 

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -12,11 +12,6 @@ defmodule Mimic.Cover do
   end
 
   @doc false
-  def private_functions_exported? do
-    function_exported?(:cover, :get_term, 1)
-  end
-
-  @doc false
   def export_private_functions do
     if not private_functions_exported?() do
       {_, binary, _} = :code.get_object_code(:cover)
@@ -46,6 +41,10 @@ defmodule Mimic.Cover do
     path = Path.expand("#{module}-#{:os.getpid()}.coverdata", ".")
     :ok = :cover.export(String.to_charlist(path), module)
     path
+  end
+
+  defp private_functions_exported? do
+    function_exported?(:cover, :get_term, 1)
   end
 
   defp rewrite_coverdata!(path, module) do

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -12,25 +12,20 @@ defmodule Mimic.Cover do
   end
 
   @doc false
-  def ensure_private_functions_exported do
-    if private_functions_exported?() do
-      export_private_functions()
-    end
-
-    :ok
-  end
-
-  @doc false
   def private_functions_exported? do
     function_exported?(:cover, :get_term, 1)
   end
 
   @doc false
   def export_private_functions do
-    {_, binary, _} = :code.get_object_code(:cover)
-    {:ok, {_, [{_, {_, abstract_code}}]}} = :beam_lib.chunks(binary, [:abstract_code])
-    {:ok, module, binary} = :compile.forms(abstract_code, [:export_all])
-    :code.load_binary(module, '', binary)
+    if not private_functions_exported?() do
+      {_, binary, _} = :code.get_object_code(:cover)
+      {:ok, {_, [{_, {_, abstract_code}}]}} = :beam_lib.chunks(binary, [:abstract_code])
+      {:ok, module, binary} = :compile.forms(abstract_code, [:export_all])
+      {:module, :cover} = :code.load_binary(module, '', binary)
+    end
+
+    :ok
   end
 
   @doc false

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -8,19 +8,13 @@ defmodule Mimic.Cover do
 
   @spec enabled?(module) :: boolean
   def enabled?(module) do
+    [module: module, is_compiled: :cover.is_compiled(module) != false] |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
     :cover.is_compiled(module) != false
   end
 
   @doc false
-  def setup_if_enabled do
-    if cover_enabled?(), do: export_private_functions()
-    :ok
-  end
-
-  @doc false
-  def cover_enabled? do
-    # Check to to see if a public function is :cover is started
-    function_exported?(:cover, :start, 0)
+  def private_functions_exported?() do
+    function_exported?(:cover, :get_term, 1)
   end
 
   @doc false

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -12,6 +12,18 @@ defmodule Mimic.Cover do
   end
 
   @doc false
+  def setup_if_needed do
+    if cover_enabled?(), do: export_private_functions()
+    :ok
+  end
+
+  @doc false
+  def cover_enabled? do
+    # Check to to see if a public function is :cover is started
+    function_exported?(:cover, :start, 0)
+  end
+
+  @doc false
   def export_private_functions do
     {_, binary, _} = :code.get_object_code(:cover)
     {:ok, {_, [{_, {_, abstract_code}}]}} = :beam_lib.chunks(binary, [:abstract_code])

--- a/lib/mimic/cover.ex
+++ b/lib/mimic/cover.ex
@@ -8,7 +8,6 @@ defmodule Mimic.Cover do
 
   @spec enabled?(module) :: boolean
   def enabled?(module) do
-    [module: module, is_compiled: :cover.is_compiled(module) != false] |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
     :cover.is_compiled(module) != false
   end
 

--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -84,10 +84,9 @@ defmodule Mimic.Module do
     end
 
     if cover_enabled? do
-      if !Cover.private_functions_exported? do
-        Cover.export_private_functions()
-      end
-      # Call dynamically to avoid compiler warning about private function
+      Cover.ensure_private_functions_exported()
+      # Call dynamically to avoid compiler warning about private function which the above function
+      # exported
       apply(:cover, :compile_beams, [[{module, binary}]])
     end
   end

--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -83,11 +83,6 @@ defmodule Mimic.Module do
       {:error, reason} -> exit({:error_loading_module, module, reason})
     end
 
-    # Cover.export_private_functions()
-    # binding() |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
-    # :cover.compile_beams([{module, binary}])
-     # |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
-
     if cover_enabled? do
       if !Cover.private_functions_exported? do
         Cover.export_private_functions()

--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -84,7 +84,7 @@ defmodule Mimic.Module do
     end
 
     if cover_enabled? do
-      Cover.ensure_private_functions_exported()
+      Cover.export_private_functions()
       # Call dynamically to avoid compiler warning about private function which the above function
       # exported
       apply(:cover, :compile_beams, [[{module, binary}]])

--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -52,12 +52,12 @@ defmodule Mimic.Module do
 
     case :compile.forms(forms, compiler_options(module)) do
       {:ok, module_name, binary} ->
-        load_binary(module_name, binary)
+        load_binary(module_name, binary, Cover.enabled?(module))
         binary
 
       {:ok, module_name, binary, _warnings} ->
-        load_binary(module_name, binary)
-        Binary
+        load_binary(module_name, binary, Cover.enabled?(module))
+        binary
     end
   end
 
@@ -77,13 +77,24 @@ defmodule Mimic.Module do
     [:return_errors | [:debug_info | options]]
   end
 
-  defp load_binary(module, binary) do
+  defp load_binary(module, binary, cover_enabled?) do
     case :code.load_binary(module, '', binary) do
       {:module, ^module} -> :ok
       {:error, reason} -> exit({:error_loading_module, module, reason})
     end
 
-    apply(:cover, :compile_beams, [[{module, binary}]])
+    # Cover.export_private_functions()
+    # binding() |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
+    # :cover.compile_beams([{module, binary}])
+     # |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
+
+    if cover_enabled? do
+      if !Cover.private_functions_exported? do
+        Cover.export_private_functions()
+      end
+      # Call dynamically to avoid compiler warning about private function
+      apply(:cover, :compile_beams, [[{module, binary}]])
+    end
   end
 
   defp rename_attribute([{:attribute, line, :module, {_, vars}} | t], new_name) do

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -463,8 +463,14 @@ defmodule Mimic.Server do
       # expect, stub, reject is called
       state = %{state | modules_to_be_copied: MapSet.put(state.modules_to_be_copied, module)}
 
+      [c_ena: Cover.enabled?(module), has: Cover.private_functions_exported?] |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
+
       state =
         if Cover.enabled?(module) do
+          if !Cover.private_functions_exported? do
+            Cover.export_private_functions()
+          end
+
           {:ok, state} = ensure_module_copied(module, state)
           state
         else

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -463,14 +463,8 @@ defmodule Mimic.Server do
       # expect, stub, reject is called
       state = %{state | modules_to_be_copied: MapSet.put(state.modules_to_be_copied, module)}
 
-      [c_ena: Cover.enabled?(module), has: Cover.private_functions_exported?] |> IO.inspect(label: "_____________________________ #{__MODULE__} AAAAAAAAAAAAAAAAA ")
-
       state =
         if Cover.enabled?(module) do
-          if !Cover.private_functions_exported? do
-            Cover.export_private_functions()
-          end
-
           {:ok, state} = ensure_module_copied(module, state)
           state
         else


### PR DESCRIPTION
Fixes #43 

Results of `mix test --cover` inside my work app are the same with or without this PR.
But what does Mimic.Cover do?
And `:cover` necessarily have been compiled before Mimic starts up?