### PR TITLE
Standardise :module_already_copied error tuple

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -360,7 +360,7 @@ defmodule Mimic do
       ExUnit.after_suite(fn _ -> Mimic.Server.reset(module) end)
       :ok
     else
-      {:error, :module_already_copied} ->
+      {:error, {:module_already_copied, _module}} ->
         :ok
 
       {:error, reason}
@@ -458,7 +458,7 @@ defmodule Mimic do
   defp ensure_module_not_copied(module) do
     case Server.marked_to_copy?(module) do
       false -> :ok
-      true -> {:error, :module_already_copied}
+      true -> {:error, {:module_already_copied, module}}
     end
   end
 


### PR DESCRIPTION
The `Mimic.Server.mark_to_copy/1` function returns a tuple in the form `{:error, {:module_already_copied, module}}` whenever the given module has already been copied before, making the function idempotent. However `Mimic.copy/1` calls a private `ensure_module_not_called/1` function that was previously returning a `{:error, :module_not_copied}` tuple.

The `Mimic.copy/1` function was only handling the version of the tuple that does not contain the module being copied.

This commit updates the code to always use tuple version that contains the module being copied, so that this error type is consistently represented throughout the codebase.