### PR TITLE
Show correct error when module has not yet been loaded

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -465,6 +465,9 @@ defmodule Mimic do
   end
 
   defp raise_if_not_exported_function!(module, fn_name, arity) do
+    # This can return {:error, :nofile}, but we don't care about that
+    Code.ensure_loaded(module)
+
     unless function_exported?(module, fn_name, arity) do
       raise ArgumentError, "Function #{fn_name}/#{arity} not defined for #{inspect(module)}"
     end

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -228,9 +228,9 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module String has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     stub(String, :split, fn x, y -> x + y end)
+                     stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
     end
 
@@ -356,9 +356,9 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module String has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     stub(String, :split, fn x, y -> x + y end)
+                     stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
     end
 
@@ -436,9 +436,9 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module String has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     expect(String, :split, fn x, y -> x + y end)
+                     stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
     end
 
@@ -569,9 +569,9 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module String has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     expect(String, :split, fn x, y -> x + y end)
+                     stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
     end
 
@@ -607,9 +607,9 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module String has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     reject(String, :split, 2)
+                     stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
     end
 
@@ -680,9 +680,9 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module String has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
                    fn ->
-                     reject(String, :split, 2)
+                     stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
     end
 

--- a/test/support/test_modules.ex
+++ b/test/support/test_modules.ex
@@ -39,6 +39,11 @@ defmodule NoStubs do
   def add(x, y), do: x + y
 end
 
+defmodule NotCopiedModule do
+  @moduledoc false
+  def inc(counter), do: counter - 1
+end
+
 defmodule Structs do
   @moduledoc false
   @enforce_keys [:foo, :bar]


### PR DESCRIPTION
I've been having wrong error message for cases when `Mimic.copy` has not been called. It has been showing `Function .... not defined for ...`. This only happened when module has not been used/loaded prior.

It has been happening because `function_exported?` has an edge case documented [in its docs](https://hexdocs.pm/elixir/1.12.3/Kernel.html#function_exported?/3):

> Note that this function does not load the module in case it is not loaded. Check [Code.ensure_loaded/1](https://hexdocs.pm/elixir/1.12.3/Code.html#ensure_loaded/1) for more information.

So, prior to this fix Mimic would mistakenly think that function does not exist, while it does exist though hasn't been loaded. 

fixes #66 