### PR TITLE
Fix typos

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -145,7 +145,7 @@ defmodule Mimic do
 
       iex> Mimic.stub(Calculator)
       ...> Calculator.add(2, 4)
-      ** (ArgumentError) Module Calculator has not been copied.  See docs for Mimic.copy/1
+      ** (ArgumentError) Module Calculator has not been copied. See docs for Mimic.copy/1
 
   """
   @spec stub(module()) :: module()
@@ -507,11 +507,11 @@ defmodule Mimic do
 
   defp validate_server_response({:error, {:module_not_copied, module}}, _action) do
     raise ArgumentError,
-          "Module #{inspect(module)} has not been copied.  See docs for Mimic.copy/1"
+          "Module #{inspect(module)} has not been copied. See docs for Mimic.copy/1"
   end
 
   defp validate_server_response(_, :copy) do
     raise ArgumentError,
-          "Failed to copy module.  See docs for Mimic.copy/1"
+          "Failed to copy module. See docs for Mimic.copy/1"
   end
 end

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -138,7 +138,7 @@ defmodule Mimic.Test do
 
     test "undefined mocked module" do
       assert_raise ArgumentError,
-                   "Module MissingModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module MissingModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub_with(MissingModule, InverseCalculator)
                    end
@@ -228,7 +228,7 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
@@ -356,7 +356,7 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
@@ -436,7 +436,7 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
@@ -569,7 +569,7 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
@@ -607,7 +607,7 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end
@@ -653,7 +653,7 @@ defmodule Mimic.Test do
     end
   end
 
-  describe "reject3/ private mode" do
+  describe "reject/3 private mode" do
     setup :set_mimic_private
 
     test "expect no call to function" do
@@ -680,7 +680,7 @@ defmodule Mimic.Test do
 
     test "raises if a non copied module is given" do
       assert_raise ArgumentError,
-                   "Module NotCopiedModule has not been copied.  See docs for Mimic.copy/1",
+                   "Module NotCopiedModule has not been copied. See docs for Mimic.copy/1",
                    fn ->
                      stub(NotCopiedModule, :inc, fn x -> x - 1 end)
                    end


### PR DESCRIPTION
While I've been fixing the other one, noticed a few typos, so decided to fix those.

- [Fix typo in test description](https://github.com/edgurgel/mimic/commit/d75006d3816f2dccfe1890d5a8783462017bde74)
- [Fix double spaces used inside error message](https://github.com/edgurgel/mimic/commit/7172b1f1f4c346a59c49014492deeaa60281dcbb)