### PR TITLE
Add functionality to call the original function

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Calculator
 verify!()
 ```
 
-Using `expect/4` on intra-module functions will not work, unless the function is referenced by it's fully qualified name. 
+Using `expect/4` on intra-module functions will not work, unless the function is referenced by it's fully qualified name.
 
 ```elixir
 defmodule Calculator do
@@ -206,7 +206,7 @@ To use DSL Mode `use Mimic.DSL` rather than `use Mimic` in your test.  DSL Mode 
 ```
 
 ## Stubs with fake module
-`stub_with/2` enable substitute function call of a module with another similar module
+`stub_with/2` enable substitute function call of a module with another similar module.
 
 ```elixir
   defmodule BadCalculator do
@@ -222,6 +222,18 @@ To use DSL Mode `use Mimic.DSL` rather than `use Mimic` in your test.  DSL Mode 
   end
 ```
 
+## Calling the original
+`call_original/3` allows to call original unmocked version of the function.
+
+```elixir
+setup :set_mimic_private
+
+test "calls original function even if it has been is stubbed" do
+  stub_with(Calculator, InverseCalculator)
+
+  assert call_original(Calculator, :add, [1, 2]) == 3
+end
+```
 
 ## Implementation Details & Performance
 

--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -375,6 +375,38 @@ defmodule Mimic do
   end
 
   @doc """
+  Call original implementation of a function.
+
+  This function allows you to call the original implementation of a function,
+  even if it has been stubbed, rejected or expected.
+
+  ## Arguments:
+
+    * `module` - the name of the module in which we're calling.
+    * `function_name` - the name of the function we're calling.
+    * `args` - the arguments of the function we're calling.
+
+  ## Raises:
+
+    * If `function_name` does not exist in `module`.
+
+  ## Example:
+
+      iex> Mimic.call_original(Calculator, :add, [1, 2])
+      3
+
+  """
+  @spec call_original(module, atom, list) :: any
+  def call_original(module, function_name, args) do
+    arity = length(args)
+
+    raise_if_not_exported_function!(module, function_name, arity)
+    func = Function.capture(Mimic.Module.original(module), function_name, arity)
+
+    Kernel.apply(func, args)
+  end
+
+  @doc """
   Verifies the current process after it exits.
 
   If you want to verify expectations for all tests, you can use


### PR DESCRIPTION
As has been suggested in #61, this adds an option to call original version of the function.

Fixes #61