### PR TITLE
Change direct :erlang calls to Elixir function calls

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -119,7 +119,7 @@ defmodule Mimic do
   """
   @spec stub(module(), atom(), function()) :: module
   def stub(module, function_name, function) do
-    arity = :erlang.fun_info(function)[:arity]
+    arity = Function.info(function)[:arity]
     raise_if_not_exported_function!(module, function_name, arity)
 
     module
@@ -228,7 +228,7 @@ defmodule Mimic do
   def expect(module, fn_name, num_calls, func)
       when is_atom(module) and is_atom(fn_name) and is_integer(num_calls) and num_calls >= 1 and
              is_function(func) do
-    arity = :erlang.fun_info(func)[:arity]
+    arity = Function.info(func)[:arity]
     raise_if_not_exported_function!(module, fn_name, arity)
 
     module
@@ -258,7 +258,7 @@ defmodule Mimic do
   """
   @spec reject(function) :: module
   def reject(function) when is_function(function) do
-    fun_info = :erlang.fun_info(function)
+    fun_info = Function.info(function)
     arity = fun_info[:arity]
     module = fun_info[:module]
     fn_name = fun_info[:name]
@@ -294,7 +294,7 @@ defmodule Mimic do
   @spec reject(module, atom, non_neg_integer) :: module
   def reject(module, function_name, arity) do
     raise_if_not_exported_function!(module, function_name, arity)
-    func = :erlang.make_fun(module, function_name, arity)
+    func = Function.capture(module, function_name, arity)
 
     module
     |> Server.expect(function_name, arity, 0, func)

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -104,7 +104,7 @@ defmodule Mimic.Server do
     arity = Enum.count(args)
     original_module = Mimic.Module.original(module)
 
-    if :erlang.function_exported(original_module, fn_name, arity) do
+    if function_exported?(original_module, fn_name, arity) do
       caller_pids = [self() | Process.get(:"$callers", [])]
 
       case allowed_pid(caller_pids, module) do


### PR DESCRIPTION
Since the library has started, Elixir standard library has evolved and introduced a few functions which originally were available through `:erlang.` calls.

This PR replaces those with the [literally](https://github.com/elixir-lang/elixir/blob/v1.12.3/lib/elixir/lib/function.ex#L85-L87) [identical](https://github.com/elixir-lang/elixir/blob/v1.17.2/lib/elixir/lib/kernel.ex#L4385-L4387) functions from the Elixir standard library. 