### PR TITLE
Support struct default values

### DIFF
--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -994,8 +994,21 @@ defmodule Mimic.Test do
       assert Structs.__info__(:struct) == [
                %{field: :foo, required: true},
                %{field: :bar, required: true},
-               %{field: :default, required: false}
+               %{field: :default, required: false},
+               %{field: :map_default, required: false}
              ]
+    end
+
+    test "copies struct fields with default values" do
+      Structs
+      |> stub(:foo, fn -> :stubbed end)
+
+      assert Structs.__struct__() == %Structs{
+               foo: nil,
+               bar: nil,
+               default: "123",
+               map_default: %{}
+             }
     end
 
     test "copies struct fields" do

--- a/test/support/test_modules.ex
+++ b/test/support/test_modules.ex
@@ -47,7 +47,7 @@ end
 defmodule Structs do
   @moduledoc false
   @enforce_keys [:foo, :bar]
-  defstruct [:foo, :bar, default: "123"]
+  defstruct [:foo, :bar, default: "123", map_default: %{}]
   def foo, do: nil
 end
 


### PR DESCRIPTION
The required fields must appear first in the defstruct, followed by 2-tuples with the default value protected by `Macro.escape/1`.

This fixes the problem I was having where `Ash.Changeset.new` errored out because the `:__metadata__` value was nil instead of an empty map.