### PR TITLE
Add elixir `1.18.0` compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,8 @@ jobs:
             coverage: true
           - otp: 27.x
             elixir: 1.17.x
+          - otp: 27.x
+            elixir: 1.18.x
     env:
       MIX_ENV: test
     steps:

--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -123,26 +123,15 @@ defmodule Mimic.Module do
 
   defp generate_mimic_struct(module) do
     if function_exported?(module, :__info__, 1) && module.__info__(:struct) != nil do
-      struct_info =
-        module.__info__(:struct)
-        |> Enum.split_with(& &1.required)
-        |> Tuple.to_list()
-        |> List.flatten()
+      struct_info = module.__info__(:struct)
 
-      required_fields = for %{field: field, required: true} <- struct_info, do: field
       struct_template = Map.from_struct(module.__struct__())
 
       struct_params =
-        for %{field: field, required: required} <- struct_info do
-          if required do
-            field
-          else
-            {field, Macro.escape(struct_template[field])}
-          end
-        end
+        for %{field: field} <- struct_info,
+            do: {field, Macro.escape(struct_template[field])}
 
       quote do
-        @enforce_keys unquote(required_fields)
         defstruct unquote(struct_params)
       end
     end

--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -2,15 +2,17 @@ defmodule Mimic.DSLTest do
   use ExUnit.Case, async: true
   use Mimic.DSL
 
+  @stub 10
+
   test "basic example" do
-    stub(Calculator.add(_x, _y), do: :stub)
+    stub(Calculator.add(_x, _y), do: @stub)
     expect Calculator.add(x, y), do: x + y
     expect Calculator.mult(x, y), do: x * y
 
     assert Calculator.add(2, 3) == 5
     assert Calculator.mult(2, 3) == 6
 
-    assert Calculator.add(2, 3) == :stub
+    assert Calculator.add(2, 3) == @stub
   end
 
   test "guards on stub" do

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -1019,18 +1019,6 @@ defmodule Mimic.Test do
   describe "structs" do
     setup :set_mimic_private
 
-    test "copies struct fields with required fields" do
-      Structs
-      |> stub(:foo, fn -> :stubbed end)
-
-      assert Structs.__info__(:struct) == [
-               %{field: :foo, required: true},
-               %{field: :bar, required: true},
-               %{field: :default, required: false},
-               %{field: :map_default, required: false}
-             ]
-    end
-
     test "copies struct fields with default values" do
       Structs
       |> stub(:foo, fn -> :stubbed end)
@@ -1048,8 +1036,8 @@ defmodule Mimic.Test do
       |> stub(:bar, fn -> :stubbed end)
 
       assert StructNoEnforceKeys.__info__(:struct) == [
-               %{field: :foo, required: false},
-               %{field: :bar, required: false}
+               %{field: :foo, default: nil},
+               %{field: :bar, default: nil}
              ]
     end
 

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -8,6 +8,7 @@ defmodule Mimic.Test do
 
   @stubbed 400
   @private_stub 500
+  @elixir_version System.version() |> Float.parse() |> elem(0)
 
   describe "no stub or expects private mode" do
     setup :set_mimic_private
@@ -1038,14 +1039,26 @@ defmodule Mimic.Test do
              }
     end
 
-    test "copies struct fields" do
-      StructNoEnforceKeys
-      |> stub(:bar, fn -> @stubbed end)
+    if @elixir_version >= 1.18 do
+      test "copies struct fields" do
+        StructNoEnforceKeys
+        |> stub(:bar, fn -> @stubbed end)
 
-      assert StructNoEnforceKeys.__info__(:struct) == [
-               %{field: :foo, default: nil},
-               %{field: :bar, default: nil}
-             ]
+        assert StructNoEnforceKeys.__info__(:struct) == [
+                 %{field: :foo, default: nil},
+                 %{field: :bar, default: nil}
+               ]
+      end
+    else
+      test "copies struct fields" do
+        StructNoEnforceKeys
+        |> stub(:bar, fn -> @stubbed end)
+
+        assert StructNoEnforceKeys.__info__(:struct) == [
+                 %{field: :foo, required: false},
+                 %{field: :bar, required: false}
+               ]
+      end
     end
 
     test "protocol still works" do


### PR DESCRIPTION
As mentioned [in this issue](https://github.com/elixir-lang/elixir/issues/14054) `required` attribute in `__info__/1` method has been deprecated.

This PR also fixes some warnings occurring in test environment regarding `mismatching type` issues.