### PR TITLE
don't soft reset if repeat_until_failure is 0

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -364,7 +364,7 @@ defmodule Mimic do
     with :ok <- ensure_module_not_copied(module),
          {:module, module} <- Code.ensure_compiled(module),
          :ok <- Mimic.Server.mark_to_copy(module, opts) do
-      if ExUnit.configuration()[:repeat_until_failure] do
+      if repeat_until_failure?() do
         ExUnit.after_suite(fn _ -> Mimic.Server.soft_reset(module) end)
       else
         ExUnit.after_suite(fn _ -> Mimic.Server.reset(module) end)
@@ -503,6 +503,14 @@ defmodule Mimic do
     case Server.marked_to_copy?(module) do
       false -> :ok
       true -> {:error, {:module_already_copied, module}}
+    end
+  end
+
+  defp repeat_until_failure? do
+    case ExUnit.configuration()[:repeat_until_failure] do
+      0 -> false
+      repeat when is_integer(repeat) -> true
+      _ -> false
     end
   end
 

--- a/test/support/test_cover.ex
+++ b/test/support/test_cover.ex
@@ -22,7 +22,7 @@ defmodule Mimic.TestCover do
       end)
 
     expected =
-      {{Calculator, :add, 2}, 5} in results &&
+      {{Calculator, :add, 2}, 9} in results &&
         {{Calculator, :mult, 2}, 5} in results &&
         {{NoStubs, :add, 2}, 2} in results && !mimic_module_cover
 


### PR DESCRIPTION
Hey sorry it looks like `ExUnit.configuration()[:repeat_until_failure]` always returns an int, so without the flag it's `0` and `0` is truthy, so it's always running the `soft_reset` now and breaking test coverage. So this just changes it to check for `0` explicitly, with a fallback in case it ends up as `nil` somehow or something.

Fixes #92 