### PR TITLE
Mimic.calls/3 to list args from each call

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,31 @@ reject(&Calculator.add/2)
 assert_raise Mimic.UnexpectedCallError, fn -> Calculator.add(4, 2) end
 ```
 
+### Calls
+
+`calls/3` returns a list of args for each call to a stubbed Mimic function.
+
+```elixir
+defmodule Calculator do
+  def mult(x, y) do
+    x * y
+  end
+
+  def negation(x) do
+    mult(x, -1)
+  end
+end
+
+Calculator
+|> expect(:mult, fn x, y -> x + y end)
+
+[] = calls(Calculator, :mult, 2)
+
+9 = Calculator.mult(3, 3)
+
+[[3, 3]] = calls(Calculator, :mult, 2)
+```
+
 ## Private and Global mode
 
 The default mode is private which means that only the process

--- a/README.md
+++ b/README.md
@@ -159,10 +159,6 @@ defmodule Calculator do
   def mult(x, y) do
     x * y
   end
-
-  def negation(x) do
-    mult(x, -1)
-  end
 end
 
 Calculator
@@ -173,6 +169,25 @@ Calculator
 9 = Calculator.mult(3, 3)
 
 [[3, 3]] = calls(Calculator, :mult, 2)
+```
+
+`calls/1` works the same way, but with a capture of the function:
+
+```elixir
+defmodule Calculator do
+  def mult(x, y) do
+    x * y
+  end
+end
+
+Calculator
+|> expect(:mult, fn x, y -> x + y end)
+
+[] = calls(&Calculator.mult/2)
+
+9 = Calculator.mult(3, 3)
+
+[[3, 3]] = calls(&Calculator.mult/2)
 ```
 
 ## Private and Global mode

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -1073,4 +1073,105 @@ defmodule Mimic.Test do
       assert to_string(s) == "{abc} - {def}"
     end
   end
+
+  describe "calls/1" do
+    setup :set_mimic_private
+
+    test "returns calls for stubbed functions" do
+      stub(Calculator, :add, fn x, y -> x + y end)
+
+      Calculator.add(1, 2)
+      Calculator.add(3, 4)
+
+      assert Mimic.calls(&Calculator.add/2) == [[3, 4], [1, 2]]
+    end
+  end
+
+  describe "calls/3 private mode" do
+    setup :set_mimic_private
+
+    test "returns calls for stubbed functions" do
+      stub(Calculator, :add, fn x, y -> x + y end)
+
+      Calculator.add(1, 2)
+      Calculator.add(3, 4)
+
+      assert Mimic.calls(Calculator, :add, 2) == [[3, 4], [1, 2]]
+    end
+
+    test "returns calls for expected functions" do
+      expect(Calculator, :add, 2, fn x, y -> x + y end)
+
+      Calculator.add(1, 2)
+      Calculator.add(3, 4)
+
+      assert Mimic.calls(Calculator, :add, 2) == [[3, 4], [1, 2]]
+    end
+
+    test "raises when mock is not defined" do
+      assert_raise ArgumentError, fn -> Mimic.calls(Date, :add, 2) end
+    end
+
+    test "raises for non-existent functions" do
+      assert_raise ArgumentError,
+                   "Function invalid/2 not defined for Calculator",
+                   fn -> Mimic.calls(Calculator, :invalid, 2) end
+    end
+
+    test "raises for non-existent modules" do
+      assert_raise ArgumentError, "Function add/2 not defined for NonExistentModule", fn ->
+        Mimic.calls(NonExistentModule, :add, 2)
+      end
+    end
+  end
+
+  describe "calls/3 global mode" do
+    setup :set_mimic_global
+
+    test "returns calls for stubbed functions" do
+      stub(Calculator, :add, fn x, y -> x + y end)
+
+      parent_pid = self()
+
+      spawn_link(fn ->
+        Calculator.add(1, 2)
+        Calculator.add(3, 4)
+        send(parent_pid, :ok)
+      end)
+
+      assert_receive :ok
+      assert Mimic.calls(Calculator, :add, 2) == [[3, 4], [1, 2]]
+    end
+
+    test "returns calls for expected functions" do
+      expect(Calculator, :add, 2, fn x, y -> x + y end)
+
+      parent_pid = self()
+
+      spawn_link(fn ->
+        Calculator.add(1, 2)
+        Calculator.add(3, 4)
+        send(parent_pid, :ok)
+      end)
+
+      assert_receive :ok
+      assert Mimic.calls(Calculator, :add, 2) == [[3, 4], [1, 2]]
+    end
+
+    test "raises when mock is not defined" do
+      assert_raise ArgumentError, fn -> Mimic.calls(Date, :add, 2) end
+    end
+
+    test "raises for non-existent functions" do
+      assert_raise ArgumentError,
+                   "Function invalid/2 not defined for Calculator",
+                   fn -> Mimic.calls(Calculator, :invalid, 2) end
+    end
+
+    test "raises for non-existent modules" do
+      assert_raise ArgumentError, "Function add/2 not defined for NonExistentModule", fn ->
+        Mimic.calls(NonExistentModule, :add, 2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This introduces arg tracking for Mimic so that tests can examine args passed into mocks. This allows for more flexibility in writing certain types of tests, or in migrating from other mock libraries that offer the same affordances.