### PR TITLE
fix: denote expectations have been filled by empty list.

### DIFF
--- a/test/dsl_test.exs
+++ b/test/dsl_test.exs
@@ -17,7 +17,7 @@ defmodule Mimic.DSLTest do
     assert Calculator.add(2, 3) == 6
 
     message =
-      ~r"expected Calculator.add/2 to be called 1 time\(s\) but it has been called 2 time\(s\)"
+      ~r"expected Calculator.add/2 to be called 0 time\(s\) but it has been called 1 time\(s\)"
 
     assert_raise Mimic.UnexpectedCallError, message, fn -> Calculator.add(5, 3) end
   end

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -153,6 +153,43 @@ defmodule Mimic.Test do
     end
   end
 
+  describe "expectations after execution" do
+    setup :set_mimic_private
+    setup :verify_on_exit!
+
+    test "expectations after execution" do
+      assert 3 == Calculator.add(1, 2)
+
+      expect(Calculator, :add, fn x, y -> x * y end)
+
+      assert 2 == Calculator.add(1, 2)
+
+      expect(Calculator, :add, fn x, y -> 2 * x * y end)
+
+      assert 4 == Calculator.add(1, 2)
+
+      message =
+        ~r"expected Calculator.add/2 to be called 0 time\(s\) but it has been called 1 time\(s\)"
+
+      assert_raise Mimic.UnexpectedCallError, message, fn -> Calculator.add(1, 2) end
+    end
+  end
+
+  describe "stubs after expectations" do
+    setup :set_mimic_private
+    setup :verify_on_exit!
+
+    test "stubs after expectations" do
+      expect(Calculator, :add, fn x, y -> x + y end)
+
+      assert Calculator.add(2, 3) == 5
+
+      stub(Calculator, :add, fn x, y -> x * y end)
+      assert Calculator.mult(2, 3) == 6
+      verify!()
+    end
+  end
+
   describe "stub/3 private mode" do
     setup :set_mimic_private
 
@@ -224,7 +261,7 @@ defmodule Mimic.Test do
       assert Calculator.add(1, 1) == @expected_2
 
       message =
-        ~r"expected Calculator.add/2 to be called 1 time\(s\) but it has been called 2 time\(s\)"
+        ~r"expected Calculator.add/2 to be called 0 time\(s\) but it has been called 1 time\(s\)"
 
       assert_raise Mimic.UnexpectedCallError, message, fn -> Calculator.add(5, 3) end
       verify!()
@@ -327,7 +364,7 @@ defmodule Mimic.Test do
         assert Calculator.add(1, 1) == @expected
 
         message =
-          ~r"expected Calculator.add/2 to be called 1 time\(s\) but it has been called 2 time\(s\)"
+          ~r"expected Calculator.add/2 to be called 0 time\(s\) but it has been called 1 time\(s\)"
 
         assert_raise Mimic.UnexpectedCallError, message, fn -> Calculator.add(5, 3) end
 
@@ -448,7 +485,7 @@ defmodule Mimic.Test do
       assert Calculator.mult(5, 0) == 5 * 2
 
       message =
-        ~r"expected Calculator.mult/2 to be called 1 time\(s\) but it has been called 2 time\(s\)"
+        ~r"expected Calculator.mult/2 to be called 0 time\(s\) but it has been called 1 time\(s\)"
 
       assert_raise Mimic.UnexpectedCallError, message, fn -> Calculator.mult(5, 3) end
     end
@@ -568,7 +605,7 @@ defmodule Mimic.Test do
         assert Calculator.mult(5, :_) == 10
 
         message =
-          ~r"expected Calculator.mult/2 to be called 1 time\(s\) but it has been called 2 time\(s\)"
+          ~r"expected Calculator.mult/2 to be called 0 time\(s\) but it has been called 1 time\(s\)"
 
         assert_raise Mimic.UnexpectedCallError, message, fn -> Calculator.mult(5, 3) end
 


### PR DESCRIPTION
I was testing out your branch that raises when all expectations are fulfilled, but I ran into an issue where when I interleaved called to the code with more expectations, which I believe you can do in the normal code, I would run into unexpected errors with confusing messages.

Because in that code, it tries to keep the last expectation around to indicate that there were ever any, and for use in error messages, it gets wonky when you try to add more expectations after that last one has been fulfilled.

Instead this just denotes that nil -> there was never any expectations, [] -> there were expectations and all of them were fulfilled [expectation | _] -> there are more expectations left to fulfill.

As part of that, the error message changes. If you apply a function and there are no more expectations left to fulfill it, it will tell you there are 0 expectations but that you were called 1 time. I think that is a more accurate message than taking the last expectation which was fulfilled and reporting on its totals.

Lastly there were no tests that interleave extra expectations while calling code in between.