### PR TITLE
fix: Mimic.Module compilation when no options are stored

### DIFF
--- a/lib/mimic/module.ex
+++ b/lib/mimic/module.ex
@@ -78,7 +78,7 @@ defmodule Mimic.Module do
   defp compiler_options(module) do
     options =
       module.module_info(:compile)
-      |> Keyword.get(:options)
+      |> Keyword.get(:options, [])
       |> Enum.filter(&(&1 != :from_core))
 
     [:return_errors | [:debug_info | options]]

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Mimic.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/edgurgel/mimic"
-  @version "2.0.1"
+  @version "2.0.2"
 
   def project do
     [


### PR DESCRIPTION
Thanks @nelsonmestevao for helping finding this issue 🎉 

