### PR TITLE
docs: fix reject documentation wording

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -251,7 +251,7 @@ defmodule Mimic do
 
   ## Raises:
 
-    * If `function` is not called by the stubbing process while calling `verify!/1`.
+    * If `function` is called by the stubbing process while calling `verify!/1`.
 
   ## Example:
 
@@ -286,7 +286,7 @@ defmodule Mimic do
 
   ## Raises:
 
-    * If `function` is not called by the stubbing process while calling `verify!/1`.
+    * If `function` is called by the stubbing process while calling `verify!/1`.
 
   ## Example:
 


### PR DESCRIPTION
Fixes #106

Changes:
- `If `function` is not called by the stubbing process while calling `verify!/1`.` -> `If `function` is called by the stubbing process while calling `verify!/1`.` in `lib/mimic.ex` (2 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
