### PR TITLE
partition Mimic.Server

### DIFF
--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -1,67 +1,77 @@
 defmodule Mimic.Server do
-  use GenServer
-  alias Mimic.Cover
   @moduledoc false
 
-  defmodule State do
-    @moduledoc false
-    defstruct verify_on_exit: MapSet.new(),
-              mode: :private,
-              global_pid: nil,
-              stubs: %{},
-              expectations: %{},
-              modules_beam: %{},
-              modules_to_be_copied: MapSet.new(),
-              reset_tasks: %{},
-              modules_opts: %{},
-              call_history: %{}
-  end
-
-  defmodule Expectation do
-    @moduledoc false
-    defstruct func: nil, num_applied_calls: 0, num_calls: nil
-  end
-
   @long_timeout Application.compile_env(:mimic, :server_timeout, 60_000)
+  @ownership_table __MODULE__
+  @partition_supervisor Mimic.Server.PartitionSupervisor
+  @supervisor Mimic.Server.Supervisor
+
+  @spec child_spec(term) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :supervisor
+    }
+  end
+
+  def start_link(_opts) do
+    partitions = Application.get_env(:mimic, :server_partitions, System.schedulers_online())
+
+    children = [
+      {Mimic.Server.Control, ownership_table: @ownership_table},
+      {PartitionSupervisor,
+       child_spec: Mimic.Server.Partition, name: @partition_supervisor, partitions: partitions}
+    ]
+
+    Supervisor.start_link(children, name: @supervisor, strategy: :rest_for_one)
+  end
 
   @spec allow(module, pid, pid) :: {:ok, module} | {:error, :global}
   def allow(module, owner_pid, allowed_pid) do
-    GenServer.call(__MODULE__, {:allow, module, owner_pid, allowed_pid})
+    GenServer.call(partition(module), {:allow, module, owner_pid, allowed_pid})
   end
 
-  @spec verify(pid) :: non_neg_integer
+  @spec verify(pid) :: list({{module, atom, arity}, non_neg_integer, non_neg_integer})
   def verify(pid) do
-    GenServer.call(__MODULE__, {:verify, pid}, @long_timeout)
+    {:verify, pid}
+    |> call_partitions(@long_timeout)
+    |> List.flatten()
   end
 
   @spec verify_on_exit(pid) :: :ok
   def verify_on_exit(pid) do
-    GenServer.call(__MODULE__, {:verify_on_exit, pid}, @long_timeout)
+    call_partitions({:verify_on_exit, pid}, @long_timeout)
+    :ok
   end
 
   @spec stub(module, atom, arity, function) ::
           {:ok, module} | {:error, :not_global_owner} | {:error, {:module_not_copied, module}}
   def stub(module, fn_name, arity, func) do
-    GenServer.call(__MODULE__, {:stub, module, fn_name, func, arity, self()}, @long_timeout)
+    GenServer.call(
+      partition(module),
+      {:stub, module, fn_name, func, arity, self()},
+      @long_timeout
+    )
   end
 
   @spec stub(module) ::
           {:ok, module} | {:error, :not_global_owner} | {:error, {:module_not_copied, module}}
   def stub(module) do
-    GenServer.call(__MODULE__, {:stub, module, self()}, @long_timeout)
+    GenServer.call(partition(module), {:stub, module, self()}, @long_timeout)
   end
 
   @spec stub_with(module, module) ::
           {:ok, module} | {:error, :not_global_owner} | {:error, {:module_not_copied, module}}
   def stub_with(module, mocking_module) do
-    GenServer.call(__MODULE__, {:stub_with, module, mocking_module, self()}, @long_timeout)
+    GenServer.call(partition(module), {:stub_with, module, mocking_module, self()}, @long_timeout)
   end
 
   @spec expect(module, atom, arity, non_neg_integer, function) ::
           {:ok, module} | {:error, :not_global_owner} | {:error, {:module_not_copied, module}}
   def expect(module, fn_name, arity, num_calls, func) do
     GenServer.call(
-      __MODULE__,
+      partition(module),
       {:expect, {module, fn_name, func, arity}, num_calls, self()},
       @long_timeout
     )
@@ -69,47 +79,57 @@ defmodule Mimic.Server do
 
   @spec set_global_mode(pid) :: :ok
   def set_global_mode(owner_pid) do
-    GenServer.call(__MODULE__, {:set_global_mode, owner_pid}, @long_timeout)
+    :ets.insert(@ownership_table, {:mode, :global, owner_pid})
+    :ok
   end
 
   @spec set_private_mode :: :ok
   def set_private_mode do
-    GenServer.call(__MODULE__, :set_private_mode, @long_timeout)
+    :ets.insert(@ownership_table, {:mode, :private})
+    :ok
   end
 
   @spec get_mode :: :private | :global
   def get_mode do
-    GenServer.call(__MODULE__, :get_mode, @long_timeout)
+    mode_info() |> elem(0)
   end
 
   @spec exit(pid) :: :ok
   def exit(pid) do
-    GenServer.cast(__MODULE__, {:exit, pid})
+    cast_partitions({:exit, pid})
+    :ok
   end
 
   @spec reset(module) :: :ok
   def reset(module) do
-    GenServer.call(__MODULE__, {:reset, module}, @long_timeout)
+    GenServer.call(partition(module), {:reset, module}, @long_timeout)
   end
 
   @spec soft_reset(module) :: :ok
-  def soft_reset(module) do
-    GenServer.call(__MODULE__, {:soft_reset, module}, @long_timeout)
+  def soft_reset(_module) do
+    set_private_mode()
+    call_partitions(:soft_reset, @long_timeout)
+    :ok
   end
 
   @spec mark_to_copy(module, keyword) :: :ok | {:error, {:module_already_copied, module}}
   def mark_to_copy(module, opts) do
-    GenServer.call(__MODULE__, {:mark_to_copy, module, opts}, @long_timeout)
+    GenServer.call(partition(module), {:mark_to_copy, module, opts}, @long_timeout)
   end
 
   @spec marked_to_copy?(module) :: boolean
   def marked_to_copy?(module) do
-    GenServer.call(__MODULE__, {:marked_to_copy?, module}, @long_timeout)
+    GenServer.call(partition(module), {:marked_to_copy?, module}, @long_timeout)
   end
 
   @spec get_calls(module, atom, arity) :: {:ok, list(list(term))} | {:error, :not_found}
   def get_calls(module, fn_name, arity) do
-    GenServer.call(__MODULE__, {:get_calls, {module, fn_name, arity}, self()})
+    caller_pids = [self() | Process.get(:"$callers", [])]
+
+    GenServer.call(
+      partition(module),
+      {:get_calls, {module, fn_name, arity}, self(), caller_pids}
+    )
   end
 
   def apply(module, fn_name, args) do
@@ -131,8 +151,61 @@ defmodule Mimic.Server do
     end
   end
 
+  def ownership_table, do: @ownership_table
+
+  def mode_info do
+    case :ets.lookup(@ownership_table, :mode) do
+      [{:mode, :global, global_pid}] -> {:global, global_pid}
+      _ -> {:private, nil}
+    end
+  end
+
+  def global_owner?(pid), do: mode_info() == {:global, pid}
+
+  def insert_owner(module, pid, owner_pid) do
+    :ets.insert(@ownership_table, {{module, pid}, owner_pid})
+  end
+
+  def insert_new_owner(module, pid, owner_pid) do
+    :ets.insert_new(@ownership_table, {{module, pid}, owner_pid})
+  end
+
+  def lookup_owner(module, pid) do
+    case :ets.lookup(@ownership_table, {module, pid}) do
+      [{{^module, ^pid}, owner_pid}] -> {:ok, owner_pid}
+      [] -> :error
+    end
+  end
+
+  def clear_ownership(pid) do
+    select = [{{{:_, pid}, :_}, [], [true]}, {{{:_, :_}, pid}, [], [true]}]
+    :ets.select_delete(@ownership_table, select)
+  end
+
+  def allowed_pid(pids, module) do
+    case mode_info() do
+      {:private, _} ->
+        Enum.find_value(pids, :none, fn pid ->
+          case lookup_owner(module, pid) do
+            {:ok, owner_pid} -> {:ok, owner_pid}
+            :error -> false
+          end
+        end)
+
+      {:global, global_pid} ->
+        case lookup_owner(module, global_pid) do
+          {:ok, owner_pid} -> {:ok, owner_pid}
+          :error -> :none
+        end
+    end
+  end
+
   defp do_apply(owner_pid, module, fn_name, arity, args) do
-    case GenServer.call(__MODULE__, {:apply, owner_pid, module, fn_name, arity, args}, :infinity) do
+    case GenServer.call(
+           partition(module),
+           {:apply, owner_pid, module, fn_name, arity, args},
+           :infinity
+         ) do
       {:ok, func} ->
         Kernel.apply(func, args)
 
@@ -157,536 +230,22 @@ defmodule Mimic.Server do
   defp apply_original(module, fn_name, args),
     do: Kernel.apply(Mimic.Module.original(module), fn_name, args)
 
-  defp allowed_pid(pids, module) do
-    case :ets.lookup(__MODULE__, :mode) do
-      [{:mode, :private}] ->
-        match = match_spec(pids, module)
+  defp partition(module), do: {:via, PartitionSupervisor, {@partition_supervisor, module}}
 
-        case :ets.select(__MODULE__, match) do
-          [] -> :none
-          [owner_pid | _] -> {:ok, owner_pid}
-        end
-
-      [{:mode, :global, global_pid}] ->
-        case :ets.lookup(__MODULE__, {global_pid, module}) do
-          [] -> :none
-          [{{^global_pid, ^module}, owner_pid}] -> {:ok, owner_pid}
-        end
-    end
+  defp call_partitions(message, timeout) do
+    Enum.map(partition_pids(), &GenServer.call(&1, message, timeout))
   end
 
-  defp match_spec(pids, module) do
-    guards = Enum.map(pids, fn pid -> {:==, :"$1", pid} end)
-    orelse = List.to_tuple([:orelse | guards])
-    [{{{:"$1", module}, :"$2"}, [orelse], [:"$2"]}]
+  defp cast_partitions(message) do
+    Enum.each(partition_pids(), &GenServer.cast(&1, message))
   end
 
-  def start_link(_) do
-    GenServer.start_link(__MODULE__, [], name: __MODULE__)
-  end
-
-  def init([]) do
-    :ets.new(__MODULE__, [:named_table, :protected, :set])
-    state = do_set_private_mode(%State{})
-    {:ok, state}
-  end
-
-  def handle_cast({:exit, pid}, state) do
-    {:noreply, clear_data_from_pid(pid, state)}
-  end
-
-  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
-    new_state =
-      if MapSet.member?(state.verify_on_exit, pid) do
-        state
-      else
-        clear_data_from_pid(pid, state)
-      end
-
-    {:noreply, new_state}
-  end
-
-  # Reset task has successfully finished
-  def handle_info({ref, :ok}, state) do
-    reset_tasks = Map.delete(state.reset_tasks, ref)
-
-    {:noreply, %{state | reset_tasks: reset_tasks}}
-  end
-
-  def handle_info(msg, state) do
-    IO.puts("handle_info with #{inspect(msg)} not handled")
-    {:noreply, state}
-  end
-
-  defp clear_data_from_pid(pid, state) do
-    expectations = Map.delete(state.expectations, pid)
-    stubs = Map.delete(state.stubs, pid)
-
-    select = [{{{pid, :_}}, [], [true]}, {{{:_, :_}, pid}, [], [true]}]
-
-    :ets.select_delete(__MODULE__, select)
-
-    state =
-      if pid == state.global_pid do
-        do_set_private_mode(state)
-      else
-        state
-      end
-
-    call_history = Map.delete(state.call_history, pid)
-
-    %{state | expectations: expectations, stubs: stubs, call_history: call_history}
-  end
-
-  defp find_stub(stubs, module, fn_name, arity, caller) do
-    case get_in(stubs, [caller, {module, fn_name, arity}]) do
-      func when is_function(func) -> {:ok, func}
-      nil -> :unexpected
-    end
-  end
-
-  defp get_call_history(state, caller, module, fn_name, arity) do
-    get_in(state.call_history, [Access.key(caller, %{}), {module, fn_name, arity}])
-  end
-
-  defp put_call_history(state, caller, module, fn_name, arity, args) do
-    call_history = get_call_history(state, caller, module, fn_name, arity) || []
-
-    %{
-      state
-      | call_history:
-          put_in(
-            state.call_history,
-            [Access.key(caller, %{}), {module, fn_name, arity}],
-            [
-              args | call_history
-            ]
-          )
-    }
-  end
-
-  def handle_call({:apply, owner_pid, module, fn_name, arity, args}, _from, state) do
-    caller =
-      if state.mode == :private do
-        owner_pid
-      else
-        state.global_pid
-      end
-
-    case get_in(state.expectations, [Access.key(caller, %{}), {module, fn_name, arity}]) do
-      [expectation | _] = expectations ->
-        case apply_call_to_expectations(expectations, expectation) do
-          {:ok, func, new_expectations} ->
-            expectations =
-              put_in(state.expectations, [caller, {module, fn_name, arity}], new_expectations)
-
-            # Track call history
-            state = put_call_history(state, caller, module, fn_name, arity, args)
-
-            {:reply, {:ok, func}, %{state | expectations: expectations}}
-
-          {:unexpected, num_calls, num_applied_calls} ->
-            {:reply, {:unexpected, num_calls, num_applied_calls}, state}
-        end
-
-      expectations ->
-        case {find_stub(state.stubs, module, fn_name, arity, caller), expectations} do
-          {{:ok, func}, _} ->
-            # Track call history for stubs too
-            state = put_call_history(state, caller, module, fn_name, arity, args)
-
-            {:reply, {:ok, func}, state}
-
-          {:unexpected, []} ->
-            # expectations for this mfa existed but they have all been fulfilled
-            {:reply, {:unexpected, :fulfilled}, state}
-
-          {:unexpected, nil} ->
-            # no expectations were ever defined for this mfa
-            # This case happens when another mfa was set-up
-            {:reply, :original, state}
-        end
-    end
-  end
-
-  def handle_call({:stub, module, fn_name, func, arity, owner}, _from, state) do
-    with {:ok, state} <- ensure_module_copied(module, state),
-         true <- valid_mode?(state, owner),
-         func <- maybe_typecheck_func(module, fn_name, func) do
-      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
-
-      :ets.insert_new(__MODULE__, {{owner, module}, owner})
-
-      {:reply, {:ok, module},
-       %{
-         state
-         | stubs: put_in(state.stubs, [Access.key(owner, %{}), {module, fn_name, arity}], func)
-       }}
-    else
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-
-      false ->
-        {:reply, {:error, :not_global_owner}, state}
-    end
-  end
-
-  def handle_call({:stub, module, owner}, _from, state) do
-    with {:ok, state} <- ensure_module_copied(module, state),
-         true <- valid_mode?(state, owner) do
-      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
-
-      :ets.insert_new(__MODULE__, {{owner, module}, owner})
-
-      internal_functions = [__info__: 1, module_info: 0, module_info: 1]
-
-      stubs =
-        module.module_info(:exports)
-        |> Enum.filter(&(&1 not in internal_functions))
-        |> Enum.reduce(state.stubs, fn {fn_name, arity}, stubs ->
-          func = stub_function(module, fn_name, arity)
-          put_in(stubs, [Access.key(owner, %{}), {module, fn_name, arity}], func)
-        end)
-
-      {:reply, {:ok, module}, %{state | stubs: stubs}}
-    else
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-
-      false ->
-        {:reply, {:error, :not_global_owner}, state}
-    end
-  end
-
-  def handle_call({:stub_with, mocked_module, mocking_module, owner}, _from, state) do
-    with {:ok, state} <- ensure_module_copied(mocked_module, state),
-         true <- valid_mode?(state, owner) do
-      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
-
-      :ets.insert_new(__MODULE__, {{owner, mocked_module}, owner})
-
-      original_module = Mimic.Module.original(mocked_module)
-
-      internal_functions = [__info__: 1, module_info: 0, module_info: 1]
-
-      mocked_public_functions =
-        original_module.module_info(:exports)
-        |> Enum.filter(&(&1 not in internal_functions))
-        |> MapSet.new()
-
-      mocking_public_functions =
-        mocking_module.module_info(:exports)
-        |> Enum.filter(&(&1 not in internal_functions))
-        |> MapSet.new()
-
-      will_be_mocked_functions =
-        MapSet.intersection(mocking_public_functions, mocked_public_functions)
-
-      will_be_stubbed_functions =
-        MapSet.difference(mocked_public_functions, mocking_public_functions)
-
-      stubs =
-        will_be_mocked_functions
-        |> Enum.reduce(state.stubs, fn {fn_name, arity}, stubs ->
-          func = anonymize_module_function(mocking_module, fn_name, arity)
-          func = maybe_typecheck_func(mocked_module, fn_name, func)
-          put_in(stubs, [Access.key(owner, %{}), {mocked_module, fn_name, arity}], func)
-        end)
-
-      stubs =
-        will_be_stubbed_functions
-        |> Enum.reduce(stubs, fn {fn_name, arity}, stubs ->
-          func = stub_function(mocked_module, fn_name, arity)
-          put_in(stubs, [Access.key(owner, %{}), {mocked_module, fn_name, arity}], func)
-        end)
-
-      {:reply, {:ok, mocked_module}, %{state | stubs: stubs}}
-    else
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-
-      false ->
-        {:reply, {:error, :not_global_owner}, state}
-    end
-  end
-
-  def handle_call({:expect, {module, fn_name, func, arity}, num_calls, owner}, _from, state) do
-    with {:ok, state} <- ensure_module_copied(module, state),
-         true <- valid_mode?(state, owner),
-         func <- maybe_typecheck_func(module, fn_name, func) do
-      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
-
-      :ets.insert_new(__MODULE__, {{owner, module}, owner})
-
-      expectation = %Expectation{func: func, num_calls: num_calls}
-
-      expectations =
-        update_in(
-          state.expectations,
-          [Access.key(owner, %{}), {module, fn_name, arity}],
-          &((&1 || []) ++ [expectation])
-        )
-
-      {:reply, {:ok, module}, %{state | expectations: expectations}}
-    else
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-
-      false ->
-        {:reply, {:error, :not_global_owner}, state}
-    end
-  end
-
-  def handle_call({:set_global_mode, owner_pid}, _from, state) do
-    {:reply, :ok, do_set_global_mode(owner_pid, state)}
-  end
-
-  def handle_call(:set_private_mode, _from, state) do
-    {:reply, :ok, do_set_private_mode(state)}
-  end
-
-  def handle_call(:get_mode, _from, state) do
-    {:reply, state.mode, state}
-  end
-
-  def handle_call({:allow, module, owner_pid, allowed_pid}, _from, state = %State{mode: :private}) do
-    case :ets.lookup(__MODULE__, {owner_pid, module}) do
-      [{{^owner_pid, ^module}, actual_owner_pid}] ->
-        :ets.insert(__MODULE__, {{allowed_pid, module}, actual_owner_pid})
-
-      [] ->
-        :ets.insert(__MODULE__, {{allowed_pid, module}, owner_pid})
-    end
-
-    {:reply, {:ok, module}, state}
-  end
-
-  def handle_call(
-        {:allow, _module, _owner_pid, _allowed_pid},
-        _from,
-        state = %State{mode: :global}
-      ) do
-    {:reply, {:error, :global}, state}
-  end
-
-  def handle_call({:verify, pid}, _from, state) do
-    expectations = state.expectations[pid] || %{}
-
-    pending =
-      for {{module, fn_name, arity}, mfa_expectations} <- expectations,
-          expectation = %Expectation{num_applied_calls: num_applied_calls, num_calls: num_calls} <-
-            mfa_expectations,
-          num_calls != num_applied_calls do
-        {{module, fn_name, arity}, expectation.num_calls, expectation.num_applied_calls}
-      end
-
-    {:reply, pending, state}
-  end
-
-  def handle_call({:verify_on_exit, pid}, _from, state) do
-    {:reply, :ok, %{state | verify_on_exit: MapSet.put(state.verify_on_exit, pid)}}
-  end
-
-  def handle_call({:soft_reset, _module}, _from, state) do
-    state = %{state | expectations: %{}, stubs: %{}, mode: :private, global_pid: nil}
-    {:reply, :ok, state}
-  end
-
-  def handle_call({:reset, module}, _from, state) do
-    state = %{state | modules_to_be_copied: MapSet.delete(state.modules_to_be_copied, module)}
-
-    tasks =
-      if Mimic.Module.copied?(module) do
-        task = Task.async(fn -> do_reset(module, state) end)
-
-        Map.put(state.reset_tasks, task.ref, task)
-      else
-        state.reset_tasks
-      end
-
-    # Clear the beam modules after starting the tasks (they read the state)
-    # This is important for umbrella apps since they'll run app after app
-    # and the modules that need to be covered will change between apps
-    state = %{state | modules_beam: Map.delete(state.modules_beam, module)}
-
-    # All modules have been reset. We should await all tasks now
-    if state.modules_to_be_copied == MapSet.new() do
-      tasks
-      |> Map.values()
-      |> Task.await_many(@long_timeout)
-
-      {:reply, :ok, %{state | reset_tasks: %{}}}
-    else
-      {:reply, :ok, %{state | reset_tasks: tasks}}
-    end
-  end
-
-  def handle_call({:marked_to_copy?, module}, _from, state) do
-    {:reply, marked_to_copy?(module, state), state}
-  end
-
-  def handle_call({:mark_to_copy, module, opts}, _from, state) do
-    if marked_to_copy?(module, state) do
-      {:reply, {:error, {:module_already_copied, module}}, state}
-    else
-      # If cover is enabled call ensure_module_copied now
-      # Otherwise just store that the module that will be copied
-      # and ensure_module_copied/2 will copy it when
-      # expect, stub, reject is called
-      state = %{
-        state
-        | modules_to_be_copied: MapSet.put(state.modules_to_be_copied, module),
-          modules_opts: Map.put(state.modules_opts, module, opts)
-      }
-
-      state =
-        if Cover.enabled_for?(module) do
-          {:ok, state} = ensure_module_copied(module, state)
-          state
-        else
-          state
-        end
-
-      {:reply, :ok, state}
-    end
-  end
-
-  def handle_call({:get_calls, {module, fn_name, arity}, owner_pid}, _from, state) do
-    caller_pids = [self() | Process.get(:"$callers", [])]
-
-    caller_pid =
-      case allowed_pid(caller_pids, module) do
-        {:ok, owner_pid} -> owner_pid
-        _ -> owner_pid
-      end
-
-    case ensure_module_copied(module, state) do
-      {:ok, state} ->
-        case pop_in(state.call_history, [Access.key(caller_pid, %{}), {module, fn_name, arity}]) do
-          {calls, call_history} when is_list(calls) ->
-            {:reply, {:ok, Enum.reverse(calls)}, %{state | call_history: call_history}}
-
-          {nil, _} ->
-            {:reply, {:ok, []}, state}
-        end
-
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
-    end
-  end
-
-  defp maybe_typecheck_func(module, fn_name, func) do
-    case module.__mimic_info__() do
-      {:ok, %{type_check: true}} ->
-        Mimic.TypeCheck.wrap(module, fn_name, func)
-
-      _ ->
-        func
-    end
-  end
-
-  defp marked_to_copy?(module, state) do
-    MapSet.member?(state.modules_to_be_copied, module)
-  end
-
-  defp do_reset(module, state) do
-    case state.modules_beam[module] do
-      {beam, coverdata} -> Cover.clear_module_and_import_coverdata!(module, beam, coverdata)
-      _ -> Mimic.Module.clear!(module)
-    end
-  end
-
-  defp ensure_module_copied(module, state) do
-    cond do
-      Mimic.Module.copied?(module) ->
-        {:ok, state}
-
-      MapSet.member?(state.modules_to_be_copied, module) ->
-        case Mimic.Module.replace!(module, state.modules_opts[module]) do
-          {beam_file, coverdata_path} ->
-            modules_beam = Map.put(state.modules_beam, module, {beam_file, coverdata_path})
-            {:ok, %{state | modules_beam: modules_beam}}
-
-          :ok ->
-            {:ok, state}
-        end
-
-      true ->
-        {:error, {:module_not_copied, module}}
-    end
-  end
-
-  defp apply_call_to_expectations(
-         expectations,
-         expectation = %Expectation{num_applied_calls: num_applied_calls, num_calls: num_calls}
-       ) do
-    cond do
-      num_applied_calls + 1 == num_calls ->
-        {:ok, expectation.func, tl(expectations)}
-
-      num_applied_calls + 1 < num_calls ->
-        {:ok, expectation.func,
-         [%{expectation | num_applied_calls: num_applied_calls + 1} | tl(expectations)]}
-
-      true ->
-        {:unexpected, expectation.num_calls, expectation.num_applied_calls + 1}
-    end
-  end
-
-  defp valid_mode?(state, caller) do
-    state.mode == :private or (state.mode == :global and state.global_pid == caller)
-  end
-
-  def monitor_if_not_verify_on_exit(pid, verify_on_exit) do
-    unless MapSet.member?(verify_on_exit, pid) do
-      Process.monitor(pid)
-    end
-  end
-
-  defp stub_function(module, fn_name, arity) do
-    args =
-      0..arity
-      |> Enum.to_list()
-      |> tl
-      |> Enum.map(fn i -> Macro.var(String.to_atom("arg_#{i}"), nil) end)
-
-    clause =
-      quote do
-        unquote_splicing(args) ->
-          mfa = Exception.format_mfa(unquote(module), unquote(fn_name), unquote(args))
-
-          raise Mimic.UnexpectedCallError,
-                "Stub! Unexpected call to #{mfa} from #{inspect(self())}"
-      end
-
-    {fun, _} = Code.eval_quoted({:fn, [], clause})
-    fun
-  end
-
-  defp anonymize_module_function(module, fn_name, arity) do
-    args =
-      0..arity
-      |> Enum.to_list()
-      |> tl
-      |> Enum.map(fn i -> Macro.var(String.to_atom("arg_#{i}"), nil) end)
-
-    clause =
-      quote do
-        unquote_splicing(args) ->
-          apply(unquote(module), unquote(fn_name), [unquote_splicing(args)])
-      end
-
-    {fun, _} = Code.eval_quoted({:fn, [], clause})
-    fun
-  end
-
-  defp do_set_global_mode(owner_pid, state) do
-    :ets.insert(__MODULE__, {:mode, :global, owner_pid})
-    %{state | global_pid: owner_pid, mode: :global}
-  end
-
-  defp do_set_private_mode(state) do
-    :ets.insert(__MODULE__, {:mode, :private})
-    %{state | global_pid: nil, mode: :private}
+  defp partition_pids do
+    @partition_supervisor
+    |> Supervisor.which_children()
+    |> Enum.flat_map(fn
+      {_id, pid, _type, _modules} when is_pid(pid) -> [pid]
+      _ -> []
+    end)
   end
 end

--- a/lib/mimic/server/control.ex
+++ b/lib/mimic/server/control.ex
@@ -1,0 +1,28 @@
+defmodule Mimic.Server.Control do
+  use GenServer
+  @moduledoc false
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    table = Keyword.fetch!(opts, :ownership_table)
+
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+
+    :ets.new(table, [
+      :named_table,
+      :public,
+      :set,
+      read_concurrency: true,
+      write_concurrency: true
+    ])
+
+    :ets.insert(table, {:mode, :private})
+
+    {:ok, %{ownership_table: table}}
+  end
+end

--- a/lib/mimic/server/partition.ex
+++ b/lib/mimic/server/partition.ex
@@ -1,0 +1,503 @@
+defmodule Mimic.Server.Partition do
+  use GenServer
+  alias Mimic.Cover
+  alias Mimic.Server
+  @moduledoc false
+
+  defmodule State do
+    @moduledoc false
+    defstruct verify_on_exit: MapSet.new(),
+              stubs: %{},
+              expectations: %{},
+              modules_beam: %{},
+              modules_to_be_copied: MapSet.new(),
+              reset_tasks: %{},
+              modules_opts: %{},
+              call_history: %{}
+  end
+
+  defmodule Expectation do
+    @moduledoc false
+    defstruct func: nil, num_applied_calls: 0, num_calls: nil
+  end
+
+  @long_timeout Application.compile_env(:mimic, :server_timeout, 60_000)
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init([]) do
+    {:ok, %State{}}
+  end
+
+  def handle_cast({:exit, pid}, state) do
+    {:noreply, clear_data_from_pid(pid, state)}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    new_state =
+      if MapSet.member?(state.verify_on_exit, pid) do
+        state
+      else
+        clear_data_from_pid(pid, state)
+      end
+
+    {:noreply, new_state}
+  end
+
+  # Reset task has successfully finished
+  def handle_info({ref, :ok}, state) do
+    reset_tasks = Map.delete(state.reset_tasks, ref)
+
+    {:noreply, %{state | reset_tasks: reset_tasks}}
+  end
+
+  def handle_info(msg, state) do
+    IO.puts("handle_info with #{inspect(msg)} not handled")
+    {:noreply, state}
+  end
+
+  def handle_call({:apply, owner_pid, module, fn_name, arity, args}, _from, state) do
+    caller =
+      case Server.mode_info() do
+        {:private, _} -> owner_pid
+        {:global, global_pid} -> global_pid
+      end
+
+    case get_in(state.expectations, [Access.key(caller, %{}), {module, fn_name, arity}]) do
+      [expectation | _] = expectations ->
+        case apply_call_to_expectations(expectations, expectation) do
+          {:ok, func, new_expectations} ->
+            expectations =
+              put_in(state.expectations, [caller, {module, fn_name, arity}], new_expectations)
+
+            # Track call history
+            state = put_call_history(state, caller, module, fn_name, arity, args)
+
+            {:reply, {:ok, func}, %{state | expectations: expectations}}
+
+          {:unexpected, num_calls, num_applied_calls} ->
+            {:reply, {:unexpected, num_calls, num_applied_calls}, state}
+        end
+
+      expectations ->
+        case {find_stub(state.stubs, module, fn_name, arity, caller), expectations} do
+          {{:ok, func}, _} ->
+            # Track call history for stubs too
+            state = put_call_history(state, caller, module, fn_name, arity, args)
+
+            {:reply, {:ok, func}, state}
+
+          {:unexpected, []} ->
+            # expectations for this mfa existed but they have all been fulfilled
+            {:reply, {:unexpected, :fulfilled}, state}
+
+          {:unexpected, nil} ->
+            # no expectations were ever defined for this mfa
+            # This case happens when another mfa was set-up
+            {:reply, :original, state}
+        end
+    end
+  end
+
+  def handle_call({:stub, module, fn_name, func, arity, owner}, _from, state) do
+    with {:ok, state} <- ensure_module_copied(module, state),
+         true <- valid_mode?(owner),
+         func <- maybe_typecheck_func(module, fn_name, func) do
+      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
+
+      Server.insert_new_owner(module, owner, owner)
+
+      {:reply, {:ok, module},
+       %{
+         state
+         | stubs: put_in(state.stubs, [Access.key(owner, %{}), {module, fn_name, arity}], func)
+       }}
+    else
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+
+      false ->
+        {:reply, {:error, :not_global_owner}, state}
+    end
+  end
+
+  def handle_call({:stub, module, owner}, _from, state) do
+    with {:ok, state} <- ensure_module_copied(module, state),
+         true <- valid_mode?(owner) do
+      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
+
+      Server.insert_new_owner(module, owner, owner)
+
+      internal_functions = [__info__: 1, module_info: 0, module_info: 1]
+
+      stubs =
+        module.module_info(:exports)
+        |> Enum.filter(&(&1 not in internal_functions))
+        |> Enum.reduce(state.stubs, fn {fn_name, arity}, stubs ->
+          func = stub_function(module, fn_name, arity)
+          put_in(stubs, [Access.key(owner, %{}), {module, fn_name, arity}], func)
+        end)
+
+      {:reply, {:ok, module}, %{state | stubs: stubs}}
+    else
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+
+      false ->
+        {:reply, {:error, :not_global_owner}, state}
+    end
+  end
+
+  def handle_call({:stub_with, mocked_module, mocking_module, owner}, _from, state) do
+    with {:ok, state} <- ensure_module_copied(mocked_module, state),
+         true <- valid_mode?(owner) do
+      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
+
+      Server.insert_new_owner(mocked_module, owner, owner)
+
+      original_module = Mimic.Module.original(mocked_module)
+
+      internal_functions = [__info__: 1, module_info: 0, module_info: 1]
+
+      mocked_public_functions =
+        original_module.module_info(:exports)
+        |> Enum.filter(&(&1 not in internal_functions))
+        |> MapSet.new()
+
+      mocking_public_functions =
+        mocking_module.module_info(:exports)
+        |> Enum.filter(&(&1 not in internal_functions))
+        |> MapSet.new()
+
+      will_be_mocked_functions =
+        MapSet.intersection(mocking_public_functions, mocked_public_functions)
+
+      will_be_stubbed_functions =
+        MapSet.difference(mocked_public_functions, mocking_public_functions)
+
+      stubs =
+        will_be_mocked_functions
+        |> Enum.reduce(state.stubs, fn {fn_name, arity}, stubs ->
+          func = anonymize_module_function(mocking_module, fn_name, arity)
+          func = maybe_typecheck_func(mocked_module, fn_name, func)
+          put_in(stubs, [Access.key(owner, %{}), {mocked_module, fn_name, arity}], func)
+        end)
+
+      stubs =
+        will_be_stubbed_functions
+        |> Enum.reduce(stubs, fn {fn_name, arity}, stubs ->
+          func = stub_function(mocked_module, fn_name, arity)
+          put_in(stubs, [Access.key(owner, %{}), {mocked_module, fn_name, arity}], func)
+        end)
+
+      {:reply, {:ok, mocked_module}, %{state | stubs: stubs}}
+    else
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+
+      false ->
+        {:reply, {:error, :not_global_owner}, state}
+    end
+  end
+
+  def handle_call({:expect, {module, fn_name, func, arity}, num_calls, owner}, _from, state) do
+    with {:ok, state} <- ensure_module_copied(module, state),
+         true <- valid_mode?(owner),
+         func <- maybe_typecheck_func(module, fn_name, func) do
+      monitor_if_not_verify_on_exit(owner, state.verify_on_exit)
+
+      Server.insert_new_owner(module, owner, owner)
+
+      expectation = %Expectation{func: func, num_calls: num_calls}
+
+      expectations =
+        update_in(
+          state.expectations,
+          [Access.key(owner, %{}), {module, fn_name, arity}],
+          &((&1 || []) ++ [expectation])
+        )
+
+      {:reply, {:ok, module}, %{state | expectations: expectations}}
+    else
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+
+      false ->
+        {:reply, {:error, :not_global_owner}, state}
+    end
+  end
+
+  def handle_call({:allow, module, owner_pid, allowed_pid}, _from, state) do
+    case Server.mode_info() do
+      {:private, _} ->
+        actual_owner_pid =
+          case Server.lookup_owner(module, owner_pid) do
+            {:ok, owner_pid} -> owner_pid
+            :error -> owner_pid
+          end
+
+        Server.insert_owner(module, allowed_pid, actual_owner_pid)
+
+        {:reply, {:ok, module}, state}
+
+      {:global, _} ->
+        {:reply, {:error, :global}, state}
+    end
+  end
+
+  def handle_call({:verify, pid}, _from, state) do
+    expectations = state.expectations[pid] || %{}
+
+    pending =
+      for {{module, fn_name, arity}, mfa_expectations} <- expectations,
+          expectation = %Expectation{num_applied_calls: num_applied_calls, num_calls: num_calls} <-
+            mfa_expectations,
+          num_calls != num_applied_calls do
+        {{module, fn_name, arity}, expectation.num_calls, expectation.num_applied_calls}
+      end
+
+    {:reply, pending, state}
+  end
+
+  def handle_call({:verify_on_exit, pid}, _from, state) do
+    {:reply, :ok, %{state | verify_on_exit: MapSet.put(state.verify_on_exit, pid)}}
+  end
+
+  def handle_call(:soft_reset, _from, state) do
+    state = %{state | expectations: %{}, stubs: %{}, call_history: %{}}
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:reset, module}, _from, state) do
+    state = %{state | modules_to_be_copied: MapSet.delete(state.modules_to_be_copied, module)}
+
+    tasks =
+      if Mimic.Module.copied?(module) do
+        task = Task.async(fn -> do_reset(module, state) end)
+
+        Map.put(state.reset_tasks, task.ref, task)
+      else
+        state.reset_tasks
+      end
+
+    # Clear the beam modules after starting the tasks (they read the state)
+    # This is important for umbrella apps since they'll run app after app
+    # and the modules that need to be covered will change between apps
+    state = %{state | modules_beam: Map.delete(state.modules_beam, module)}
+
+    # All modules in this partition have been reset. We should await all tasks now
+    if state.modules_to_be_copied == MapSet.new() do
+      tasks
+      |> Map.values()
+      |> Task.await_many(@long_timeout)
+
+      {:reply, :ok, %{state | reset_tasks: %{}}}
+    else
+      {:reply, :ok, %{state | reset_tasks: tasks}}
+    end
+  end
+
+  def handle_call({:marked_to_copy?, module}, _from, state) do
+    {:reply, marked_to_copy?(module, state), state}
+  end
+
+  def handle_call({:mark_to_copy, module, opts}, _from, state) do
+    if marked_to_copy?(module, state) do
+      {:reply, {:error, {:module_already_copied, module}}, state}
+    else
+      # If cover is enabled call ensure_module_copied now
+      # Otherwise just store that the module that will be copied
+      # and ensure_module_copied/2 will copy it when
+      # expect, stub, reject is called
+      state = %{
+        state
+        | modules_to_be_copied: MapSet.put(state.modules_to_be_copied, module),
+          modules_opts: Map.put(state.modules_opts, module, opts)
+      }
+
+      state =
+        if Cover.enabled_for?(module) do
+          {:ok, state} = ensure_module_copied(module, state)
+          state
+        else
+          state
+        end
+
+      {:reply, :ok, state}
+    end
+  end
+
+  def handle_call({:get_calls, {module, fn_name, arity}, owner_pid, caller_pids}, _from, state) do
+    caller_pid =
+      case Server.allowed_pid(caller_pids, module) do
+        {:ok, owner_pid} -> owner_pid
+        _ -> owner_pid
+      end
+
+    case ensure_module_copied(module, state) do
+      {:ok, state} ->
+        case pop_in(state.call_history, [Access.key(caller_pid, %{}), {module, fn_name, arity}]) do
+          {calls, call_history} when is_list(calls) ->
+            {:reply, {:ok, Enum.reverse(calls)}, %{state | call_history: call_history}}
+
+          {nil, _} ->
+            {:reply, {:ok, []}, state}
+        end
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  defp clear_data_from_pid(pid, state) do
+    expectations = Map.delete(state.expectations, pid)
+    stubs = Map.delete(state.stubs, pid)
+
+    Server.clear_ownership(pid)
+
+    if Server.global_owner?(pid) do
+      Server.set_private_mode()
+    end
+
+    call_history = Map.delete(state.call_history, pid)
+
+    %{state | expectations: expectations, stubs: stubs, call_history: call_history}
+  end
+
+  defp find_stub(stubs, module, fn_name, arity, caller) do
+    case get_in(stubs, [caller, {module, fn_name, arity}]) do
+      func when is_function(func) -> {:ok, func}
+      nil -> :unexpected
+    end
+  end
+
+  defp get_call_history(state, caller, module, fn_name, arity) do
+    get_in(state.call_history, [Access.key(caller, %{}), {module, fn_name, arity}])
+  end
+
+  defp put_call_history(state, caller, module, fn_name, arity, args) do
+    call_history = get_call_history(state, caller, module, fn_name, arity) || []
+
+    %{
+      state
+      | call_history:
+          put_in(
+            state.call_history,
+            [Access.key(caller, %{}), {module, fn_name, arity}],
+            [
+              args | call_history
+            ]
+          )
+    }
+  end
+
+  defp maybe_typecheck_func(module, fn_name, func) do
+    case module.__mimic_info__() do
+      {:ok, %{type_check: true}} ->
+        Mimic.TypeCheck.wrap(module, fn_name, func)
+
+      _ ->
+        func
+    end
+  end
+
+  defp marked_to_copy?(module, state) do
+    MapSet.member?(state.modules_to_be_copied, module)
+  end
+
+  defp do_reset(module, state) do
+    case state.modules_beam[module] do
+      {beam, coverdata} -> Cover.clear_module_and_import_coverdata!(module, beam, coverdata)
+      _ -> Mimic.Module.clear!(module)
+    end
+  end
+
+  defp ensure_module_copied(module, state) do
+    cond do
+      Mimic.Module.copied?(module) ->
+        {:ok, state}
+
+      MapSet.member?(state.modules_to_be_copied, module) ->
+        case Mimic.Module.replace!(module, state.modules_opts[module]) do
+          {beam_file, coverdata_path} ->
+            modules_beam = Map.put(state.modules_beam, module, {beam_file, coverdata_path})
+            {:ok, %{state | modules_beam: modules_beam}}
+
+          :ok ->
+            {:ok, state}
+        end
+
+      true ->
+        {:error, {:module_not_copied, module}}
+    end
+  end
+
+  defp apply_call_to_expectations(
+         expectations,
+         expectation = %Expectation{num_applied_calls: num_applied_calls, num_calls: num_calls}
+       ) do
+    cond do
+      num_applied_calls + 1 == num_calls ->
+        {:ok, expectation.func, tl(expectations)}
+
+      num_applied_calls + 1 < num_calls ->
+        {:ok, expectation.func,
+         [%{expectation | num_applied_calls: num_applied_calls + 1} | tl(expectations)]}
+
+      true ->
+        {:unexpected, expectation.num_calls, expectation.num_applied_calls + 1}
+    end
+  end
+
+  defp valid_mode?(caller) do
+    case Server.mode_info() do
+      {:private, _} -> true
+      {:global, global_pid} -> global_pid == caller
+    end
+  end
+
+  def monitor_if_not_verify_on_exit(pid, verify_on_exit) do
+    unless MapSet.member?(verify_on_exit, pid) do
+      Process.monitor(pid)
+    end
+  end
+
+  defp stub_function(module, fn_name, arity) do
+    args =
+      0..arity
+      |> Enum.to_list()
+      |> tl
+      |> Enum.map(fn i -> Macro.var(String.to_atom("arg_#{i}"), nil) end)
+
+    clause =
+      quote do
+        unquote_splicing(args) ->
+          mfa = Exception.format_mfa(unquote(module), unquote(fn_name), unquote(args))
+
+          raise Mimic.UnexpectedCallError,
+                "Stub! Unexpected call to #{mfa} from #{inspect(self())}"
+      end
+
+    {fun, _} = Code.eval_quoted({:fn, [], clause})
+    fun
+  end
+
+  defp anonymize_module_function(module, fn_name, arity) do
+    args =
+      0..arity
+      |> Enum.to_list()
+      |> tl
+      |> Enum.map(fn i -> Macro.var(String.to_atom("arg_#{i}"), nil) end)
+
+    clause =
+      quote do
+        unquote_splicing(args) ->
+          apply(unquote(module), unquote(fn_name), [unquote_splicing(args)])
+      end
+
+    {fun, _} = Code.eval_quoted({:fn, [], clause})
+    fun
+  end
+end


### PR DESCRIPTION
Hey there,

I ran into Mimic.Server being a bottleneck for async tests in a codebase. My idea was to partition Mimic.Server by module with Elixir's `PartitionSupervisor`. I asked Codex with GPT-5.5 to set up a test project with a lot of tests using Mimic, measure test time, adjust the code to be partitioned, and then benchmark against the baseline.

Those are the results:

``` 
Before: 

 192 tests, 0 failures 
 Finished in 17.9 seconds 
 elapsed=0:19.01 user=96.84 sys=21.71 max_rss_kb=787216 

 After: 

 192 tests, 0 failures 
 Finished in 6.5 seconds 
 elapsed=0:07.21 user=48.72 sys=3.83 max_rss_kb=411424
```

It is worth testing those changes with more real world projects though, so I'm leaving this here mostly as a potential starting point, not suggesting to merge as is. I might have missed some edge cases.

---

This PR changes Mimic.Server from a single GenServer to be partitioned using a PartitionSupervisor.

Closes #115.

Assisted-by: GPT-5.5