### PR TITLE
fix: verify_on_exit! cleans up even when it raises

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -436,8 +436,11 @@ defmodule Mimic do
     Server.verify_on_exit(pid)
 
     Callbacks.on_exit(Mimic, fn ->
-      verify!(pid)
-      Server.exit(pid)
+      try do
+        verify!(pid)
+      after
+        Server.exit(pid)
+      end
     end)
   end
 

--- a/test/edge_case_test.exs
+++ b/test/edge_case_test.exs
@@ -20,5 +20,32 @@ defmodule Mimic.EdgeCase do
         verify!(child_pid)
       end
     end
+
+  end
+
+  ################### Bug demonstration ###################
+  # Run with `mix test test/edge_case_test.exs --seed 0`
+  # Because it depends on the order of the tests
+  describe "failed verification in global mode" do
+    # must be in global mode
+    setup :set_mimic_global
+    # must verify on exit
+    setup :verify_on_exit!
+
+    # this test must run first
+    test "reports an unmet expectation on exit" do
+      # must have expecation remaining
+      expect(Calculator, :add, 2, fn x, y -> x + y end)
+      assert Calculator.add(1, 2) == 3
+    end
+  end
+
+  describe "the test after a failed global verification" do
+    # this test must run after the previous test
+    test "can use Mimic" do
+      # this stub fails because the global owner was never cleaned up
+      stub(Calculator, :add, fn _, _ -> 0 end)
+      assert Calculator.add(1, 2) == 0
+    end
   end
 end

--- a/test/edge_case_test.exs
+++ b/test/edge_case_test.exs
@@ -20,32 +20,5 @@ defmodule Mimic.EdgeCase do
         verify!(child_pid)
       end
     end
-
-  end
-
-  ################### Bug demonstration ###################
-  # Run with `mix test test/edge_case_test.exs --seed 0`
-  # Because it depends on the order of the tests
-  describe "failed verification in global mode" do
-    # must be in global mode
-    setup :set_mimic_global
-    # must verify on exit
-    setup :verify_on_exit!
-
-    # this test must run first
-    test "reports an unmet expectation on exit" do
-      # must have expecation remaining
-      expect(Calculator, :add, 2, fn x, y -> x + y end)
-      assert Calculator.add(1, 2) == 3
-    end
-  end
-
-  describe "the test after a failed global verification" do
-    # this test must run after the previous test
-    test "can use Mimic" do
-      # this stub fails because the global owner was never cleaned up
-      stub(Calculator, :add, fn _, _ -> 0 end)
-      assert Calculator.add(1, 2) == 0
-    end
   end
 end

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -1297,6 +1297,33 @@ defmodule Mimic.Test do
     end
   end
 
+  describe "verify_on_exit!/1" do
+    setup :set_mimic_private
+
+    test "cleans up when exit verification raises" do
+      # This process stands in for an ExUnit test process. Registering it with
+      # ExUnit allows verify_on_exit!/0 to install its real on-exit callback.
+      {test_pid, monitor_ref} =
+        spawn_monitor(fn ->
+          ExUnit.OnExitHandler.register(self())
+          verify_on_exit!()
+
+          # Leave an expectation pending so verification raises on exit.
+          expect(Calculator, :add, fn x, y -> x + y end)
+        end)
+
+      assert_receive {:DOWN, ^monitor_ref, :process, ^test_pid, :normal}
+
+      # Run the registered callback manually so its expected verification error
+      # can be asserted without failing this test.
+      assert {:error, %Mimic.VerificationError{}, _stacktrace} =
+               ExUnit.OnExitHandler.run(test_pid, 1_000)
+
+      # The callback cleaned up the pending expectation even though verification raised.
+      assert Mimic.Server.verify(test_pid) == []
+    end
+  end
+
   describe "set_mimic_global/1" do
     test "raises if the test case is async" do
       message = ~r/Mimic cannot be set to global mode when the ExUnit case is async/


### PR DESCRIPTION
We ran into a edge case where a single failed test with Mimic in global mode can cause all subsequent Mimic operations to fail, making it hard to identify the original test that failed. 

The fix is really simple, just use `try`/`after` in the on_exit callback. 

This PR is 3 commits:
Commit 1: A demonstration test that shows how to reproduce the bug
Commit 2: The fix
Commit 3: Removal of the demonstration test (because by definition it cannot pass because reproducing the bug requires a failing test)

The demonstration test is removed, but a regression test is included. 

You can checkout commit 1 and run the demonstration test, but this is the output for your convenience: 
```
  1) test failed verification in global mode reports an unmet expectation on exit (Mimic.EdgeCase)
     test/edge_case_test.exs:36
     ** (Mimic.VerificationError) error while verifying mocks for #PID<0.203.0>:

       * expected Calculator.add/2 to be invoked 2 time(s) but it has been called 1 time(s)
     stacktrace:
       (mimic 2.3.0) lib/mimic.ex:499: Mimic.verify!/1
       (mimic 2.3.0) lib/mimic.ex:439: anonymous fn/1 in Mimic.verify_on_exit!/1
       (ex_unit 1.19.2) lib/ex_unit/on_exit_handler.ex:140: ExUnit.OnExitHandler.exec_callback/1
       (ex_unit 1.19.2) lib/ex_unit/on_exit_handler.ex:126: ExUnit.OnExitHandler.on_exit_runner_loop/0



  2) test the test after a failed global verification can use Mimic (Mimic.EdgeCase)
     test/edge_case_test.exs:45
     ** (ArgumentError) Stub cannot be called by the current process. Only the global owner is allowed.
     code: stub(Calculator, :add, fn _, _ -> 0 end)
     stacktrace:
       (mimic 2.3.0) lib/mimic.ex:634: Mimic.validate_server_response/2
       test/edge_case_test.exs:47: (test)
```

The first test failed legitimately, but leaves behind an uncleaned global setup. 
Subsequent tests then fail to stub/expect. 