### PR TITLE
fix: report asynchronous expectation assertion failures

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -436,8 +436,11 @@ defmodule Mimic do
     Server.verify_on_exit(pid)
 
     Callbacks.on_exit(Mimic, fn ->
-      verify!(pid)
-      Server.exit(pid)
+      try do
+        verify!(pid)
+      after
+        Server.exit(pid)
+      end
     end)
   end
 
@@ -485,7 +488,7 @@ defmodule Mimic do
   """
   @spec verify!(pid()) :: :ok
   def verify!(pid \\ self()) do
-    pending = Server.verify(pid)
+    {pending, assertion_failures} = Server.verify(pid)
 
     messages =
       for {{module, name, arity}, num_calls, num_applied_calls} <- pending do
@@ -495,12 +498,17 @@ defmodule Mimic do
           "but it has been called #{num_applied_calls} time(s)"
       end
 
-    if messages != [] do
-      raise VerificationError,
-            "error while verifying mocks for #{inspect(pid)}:\n\n" <> Enum.join(messages, "\n")
-    end
+    case assertion_failures do
+      [{error, stacktrace} | _] ->
+        reraise error, stacktrace
 
-    :ok
+      [] when messages != [] ->
+        raise VerificationError,
+              "error while verifying mocks for #{inspect(pid)}:\n\n" <> Enum.join(messages, "\n")
+
+      [] ->
+        :ok
+    end
   end
 
   @doc "Returns the current mode (`:global` or `:private`)"

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -14,7 +14,8 @@ defmodule Mimic.Server do
               modules_to_be_copied: MapSet.new(),
               reset_tasks: %{},
               modules_opts: %{},
-              call_history: %{}
+              call_history: %{},
+              assertion_failures: %{}
   end
 
   defmodule Expectation do
@@ -29,7 +30,7 @@ defmodule Mimic.Server do
     GenServer.call(__MODULE__, {:allow, module, owner_pid, allowed_pid})
   end
 
-  @spec verify(pid) :: non_neg_integer
+  @spec verify(pid) :: {list(), list()}
   def verify(pid) do
     GenServer.call(__MODULE__, {:verify, pid}, @long_timeout)
   end
@@ -134,7 +135,20 @@ defmodule Mimic.Server do
   defp do_apply(owner_pid, module, fn_name, arity, args) do
     case GenServer.call(__MODULE__, {:apply, owner_pid, module, fn_name, arity, args}, :infinity) do
       {:ok, func} ->
-        Kernel.apply(func, args)
+        try do
+          Kernel.apply(func, args)
+        rescue
+          error in ExUnit.AssertionError ->
+            if self() != owner_pid do
+              GenServer.call(
+                __MODULE__,
+                {:assertion_failure, owner_pid, error, __STACKTRACE__},
+                @long_timeout
+              )
+            end
+
+            reraise error, __STACKTRACE__
+        end
 
       :original ->
         apply_original(module, fn_name, args)
@@ -220,6 +234,7 @@ defmodule Mimic.Server do
   defp clear_data_from_pid(pid, state) do
     expectations = Map.delete(state.expectations, pid)
     stubs = Map.delete(state.stubs, pid)
+    assertion_failures = Map.delete(state.assertion_failures, pid)
 
     select = [{{{pid, :_}}, [], [true]}, {{{:_, :_}, pid}, [], [true]}]
 
@@ -234,7 +249,13 @@ defmodule Mimic.Server do
 
     call_history = Map.delete(state.call_history, pid)
 
-    %{state | expectations: expectations, stubs: stubs, call_history: call_history}
+    %{
+      state
+      | expectations: expectations,
+        stubs: stubs,
+        call_history: call_history,
+        assertion_failures: assertion_failures
+    }
   end
 
   defp find_stub(stubs, module, fn_name, arity, caller) do
@@ -479,7 +500,18 @@ defmodule Mimic.Server do
         {{module, fn_name, arity}, expectation.num_calls, expectation.num_applied_calls}
       end
 
-    {:reply, pending, state}
+    assertion_failures = state.assertion_failures[pid] || []
+
+    {:reply, {pending, assertion_failures}, state}
+  end
+
+  def handle_call({:assertion_failure, owner_pid, error, stacktrace}, _from, state) do
+    assertion_failures =
+      Map.update(state.assertion_failures, owner_pid, [{error, stacktrace}], fn failures ->
+        failures ++ [{error, stacktrace}]
+      end)
+
+    {:reply, :ok, %{state | assertion_failures: assertion_failures}}
   end
 
   def handle_call({:verify_on_exit, pid}, _from, state) do
@@ -487,7 +519,15 @@ defmodule Mimic.Server do
   end
 
   def handle_call({:soft_reset, _module}, _from, state) do
-    state = %{state | expectations: %{}, stubs: %{}, mode: :private, global_pid: nil}
+    state = %{
+      state
+      | expectations: %{},
+        stubs: %{},
+        mode: :private,
+        global_pid: nil,
+        assertion_failures: %{}
+    }
+
     {:reply, :ok, state}
   end
 

--- a/test/edge_case_test.exs
+++ b/test/edge_case_test.exs
@@ -21,4 +21,105 @@ defmodule Mimic.EdgeCase do
       end
     end
   end
+
+  describe "asynchronous expectation failures" do
+    setup :set_mimic_private
+
+    test "reports an assertion raised in a supervised task during explicit verification" do
+      supervisor = start_supervised!(Task.Supervisor)
+
+      expect(Calculator, :add, fn _, _ ->
+        assert false, "detached task failure"
+      end)
+
+      {:ok, task_pid} = Task.Supervisor.start_child(supervisor, fn -> Calculator.add(1, 2) end)
+      ref = Process.monitor(task_pid)
+
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, {%ExUnit.AssertionError{}, _stacktrace}}
+
+      assert_raise ExUnit.AssertionError, ~r/detached task failure/, fn ->
+        verify!()
+      end
+    end
+
+    test "successful supervised task calls still pass on-exit verification" do
+      verify_on_exit!()
+      supervisor = start_supervised!(Task.Supervisor)
+
+      expect(Calculator, :add, fn x, y -> x + y end)
+
+      parent = self()
+
+      {:ok, task_pid} =
+        Task.Supervisor.start_child(supervisor, fn ->
+          send(parent, {:result, Calculator.add(1, 2)})
+        end)
+
+      ref = Process.monitor(task_pid)
+
+      assert_receive {:result, 3}
+      assert_receive {:DOWN, ^ref, :process, ^task_pid, :normal}
+    end
+
+    test "reports an assertion raised in a generic allowed process" do
+      expect(Calculator, :add, fn _, _ ->
+        assert false, "allowed process failure"
+      end)
+
+      child_pid =
+        spawn(fn ->
+          receive do
+            :call -> Calculator.add(1, 2)
+          end
+        end)
+
+      Calculator |> allow(self(), child_pid)
+
+      ref = Process.monitor(child_pid)
+      send(child_pid, :call)
+
+      assert_receive {:DOWN, ^ref, :process, ^child_pid, {%ExUnit.AssertionError{}, _stacktrace}}
+
+      assert_raise ExUnit.AssertionError, ~r/allowed process failure/, fn ->
+        verify!()
+      end
+    end
+
+    test "owner cleanup clears recorded assertion failures" do
+      expect(Calculator, :add, fn _, _ ->
+        assert false, "failure before cleanup"
+      end)
+
+      child_pid =
+        spawn(fn ->
+          receive do
+            :call -> Calculator.add(1, 2)
+          end
+        end)
+
+      Calculator |> allow(self(), child_pid)
+
+      ref = Process.monitor(child_pid)
+      send(child_pid, :call)
+      assert_receive {:DOWN, ^ref, :process, ^child_pid, {%ExUnit.AssertionError{}, _stacktrace}}
+
+      Mimic.Server.exit(self())
+
+      expect(Calculator, :add, fn x, y -> x + y end)
+      assert Calculator.add(1, 2) == 3
+      assert verify!() == :ok
+    end
+
+    test "an assertion raised by the expectation owner propagates only once" do
+      expect(Calculator, :add, fn _, _ ->
+        assert false, "owner process failure"
+      end)
+
+      assert_raise ExUnit.AssertionError, ~r/owner process failure/, fn ->
+        Calculator.add(1, 2)
+      end
+
+      assert verify!() == :ok
+    end
+  end
 end


### PR DESCRIPTION
Wrap execution of a resolved expectation in `Mimic.Server.do_apply/5` so an `ExUnit.AssertionError` raised outside the expectation owner process is synchronously recorded against that owner before being re-raised in the child. An assertion raised inside a `Mimic.expect/4` implementation running in a detached child process can terminate only that process, allowing the owning ExUnit test to pass.

Start an expectation-backed call with `Task.Supervisor.start_child/3`, wait for the child to terminate after a failing assertion, and verify that `Mimic.verify!/1` raises the captured `ExUnit.AssertionError` instead of treating the fulfilled expectation as success; Run a successful expectation from a supervised task and verify that normal on-exit verification still succeeds without a recorded failure.

Fixes #109
