### PR TITLE
Lazy allowances

### DIFF
--- a/lib/mimic.ex
+++ b/lib/mimic.ex
@@ -312,8 +312,9 @@ defmodule Mimic do
 
     * `module` - the copied module.
     * `owner_pid` - the process ID of the process which created the stub.
-    * `allowed_pid` - the process ID of the process which should also be allowed
-      to use this stub.
+    * `allowed_pid_or_fun` - the process ID of the process which should also be
+      allowed to use this stub, or a zero-arity function that returns a pid (or
+      list of pids) to be resolved lazily at invocation time.
 
   ## Raises:
 
@@ -338,9 +339,34 @@ defmodule Mimic do
     |> Task.await
   end
   ```
+
+  ## Lazy (deferred) allowances
+
+  If the process you want to allow doesn't exist yet at the time you set up
+  expectations, you can pass a function instead of a pid. The function will be
+  called on each mock invocation to determine whether the caller is allowed.
+
+  ```elixir
+  test "allows a process that starts later" do
+    Calculator
+    |> expect(:add, fn x, y -> x + y end)
+    |> allow(self(), fn -> GenServer.whereis(MyServer) end)
+
+    start_supervised!(MyServer)
+    # MyServer can now call Calculator.add and hit the expectation
+  end
+  ```
   """
-  @spec allow(module(), pid(), pid()) :: module() | {:error, atom()}
-  def allow(module, owner_pid, allowed_pid) do
+  @spec allow(module(), pid(), pid() | (-> pid() | [pid()] | nil)) :: module() | {:error, atom()}
+  def allow(module, owner_pid, allowed_pid_or_fun)
+
+  def allow(module, owner_pid, fun) when is_function(fun, 0) do
+    module
+    |> Server.allow_lazy(owner_pid, fun)
+    |> validate_server_response(:allow)
+  end
+
+  def allow(module, owner_pid, allowed_pid) when is_pid(allowed_pid) do
     module
     |> Server.allow(owner_pid, allowed_pid)
     |> validate_server_response(:allow)

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -3,6 +3,9 @@ defmodule Mimic.Server do
   alias Mimic.Cover
   @moduledoc false
 
+  # Fast-path lookup to avoid a GenServer call when no lazy allowances exist for a module
+  @lazy_modules_table :mimic_lazy_modules
+
   defmodule State do
     @moduledoc false
     defstruct verify_on_exit: MapSet.new(),
@@ -14,7 +17,8 @@ defmodule Mimic.Server do
               modules_to_be_copied: MapSet.new(),
               reset_tasks: %{},
               modules_opts: %{},
-              call_history: %{}
+              call_history: %{},
+              lazy_allowances: %{}
   end
 
   defmodule Expectation do
@@ -27,6 +31,11 @@ defmodule Mimic.Server do
   @spec allow(module, pid, pid) :: {:ok, module} | {:error, :global}
   def allow(module, owner_pid, allowed_pid) do
     GenServer.call(__MODULE__, {:allow, module, owner_pid, allowed_pid})
+  end
+
+  @spec allow_lazy(module, pid, (-> pid | [pid])) :: {:ok, module} | {:error, :global}
+  def allow_lazy(module, owner_pid, fun) when is_function(fun, 0) do
+    GenServer.call(__MODULE__, {:allow_lazy, module, owner_pid, fun})
   end
 
   @spec verify(pid) :: non_neg_integer
@@ -119,15 +128,21 @@ defmodule Mimic.Server do
     if function_exported?(original_module, fn_name, arity) do
       caller_pids = [self() | Process.get(:"$callers", [])]
 
-      case allowed_pid(caller_pids, module) do
-        {:ok, owner_pid} ->
-          do_apply(owner_pid, module, fn_name, arity, args)
-
-        _ ->
-          apply_original(module, fn_name, args)
+      with :none <- allowed_pid(caller_pids, module),
+           :none <- resolve_lazy_allowance(caller_pids, module) do
+        apply_original(module, fn_name, args)
+      else
+        {:ok, owner_pid} -> do_apply(owner_pid, module, fn_name, arity, args)
       end
     else
       raise Mimic.Error, module: module, fn_name: fn_name, arity: arity
+    end
+  end
+
+  defp resolve_lazy_allowance(caller_pids, module) do
+    case :ets.lookup(@lazy_modules_table, module) do
+      [_ | _] -> GenServer.call(__MODULE__, {:resolve_lazy, module, caller_pids})
+      [] -> :none
     end
   end
 
@@ -186,6 +201,7 @@ defmodule Mimic.Server do
 
   def init([]) do
     :ets.new(__MODULE__, [:named_table, :protected, :set])
+    :ets.new(@lazy_modules_table, [:named_table, :protected, :set])
     state = do_set_private_mode(%State{})
     {:ok, state}
   end
@@ -234,7 +250,28 @@ defmodule Mimic.Server do
 
     call_history = Map.delete(state.call_history, pid)
 
-    %{state | expectations: expectations, stubs: stubs, call_history: call_history}
+    removed_modules =
+      state.lazy_allowances
+      |> Enum.filter(fn {{owner_pid, _module}, _funs} -> owner_pid == pid end)
+      |> Enum.map(fn {{_owner_pid, module}, _funs} -> module end)
+
+    lazy_allowances =
+      state.lazy_allowances
+      |> Enum.reject(fn {{owner_pid, _module}, _funs} -> owner_pid == pid end)
+      |> Map.new()
+
+    for module <- removed_modules do
+      still_has_lazy? = Enum.any?(lazy_allowances, fn {{_owner_pid, m}, _funs} -> m == module end)
+      if not still_has_lazy?, do: :ets.delete(@lazy_modules_table, module)
+    end
+
+    %{
+      state
+      | expectations: expectations,
+        stubs: stubs,
+        call_history: call_history,
+        lazy_allowances: lazy_allowances
+    }
   end
 
   defp find_stub(stubs, module, fn_name, arity, caller) do
@@ -468,6 +505,33 @@ defmodule Mimic.Server do
     {:reply, {:error, :global}, state}
   end
 
+  def handle_call({:allow_lazy, module, owner_pid, fun}, _from, state = %State{mode: :private}) do
+    monitor_if_not_verify_on_exit(owner_pid, state.verify_on_exit)
+    :ets.insert(@lazy_modules_table, {module, true})
+
+    actual_owner =
+      case :ets.lookup(__MODULE__, {owner_pid, module}) do
+        [{{^owner_pid, ^module}, actual_owner_pid}] -> actual_owner_pid
+        [] -> owner_pid
+      end
+
+    lazy_allowances =
+      Map.update(state.lazy_allowances, {actual_owner, module}, [fun], &[fun | &1])
+
+    {:reply, {:ok, module}, %{state | lazy_allowances: lazy_allowances}}
+  end
+
+  def handle_call({:allow_lazy, _module, _owner_pid, _fun}, _from, state = %State{mode: :global}) do
+    {:reply, {:error, :global}, state}
+  end
+
+  def handle_call({:resolve_lazy, module, caller_pids}, _from, state) do
+    case find_lazy_owner(state.lazy_allowances, module, caller_pids) do
+      {:ok, owner_pid} -> {:reply, {:ok, owner_pid}, state}
+      :none -> {:reply, :none, state}
+    end
+  end
+
   def handle_call({:verify, pid}, _from, state) do
     expectations = state.expectations[pid] || %{}
 
@@ -487,7 +551,17 @@ defmodule Mimic.Server do
   end
 
   def handle_call({:soft_reset, _module}, _from, state) do
-    state = %{state | expectations: %{}, stubs: %{}, mode: :private, global_pid: nil}
+    :ets.delete_all_objects(@lazy_modules_table)
+
+    state = %{
+      state
+      | expectations: %{},
+        stubs: %{},
+        mode: :private,
+        global_pid: nil,
+        lazy_allowances: %{}
+    }
+
     {:reply, :ok, state}
   end
 
@@ -687,5 +761,23 @@ defmodule Mimic.Server do
   defp do_set_private_mode(state) do
     :ets.insert(__MODULE__, {:mode, :private})
     %{state | global_pid: nil, mode: :private}
+  end
+
+  defp find_lazy_owner(lazy_allowances, module, caller_pids) do
+    Enum.find_value(lazy_allowances, :none, fn
+      {{owner_pid, ^module}, funs} ->
+        if any_pid_matches?(funs, caller_pids), do: {:ok, owner_pid}
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp any_pid_matches?(funs, caller_pids) do
+    Enum.any?(funs, fn fun ->
+      fun.()
+      |> List.wrap()
+      |> Enum.any?(&(&1 in caller_pids))
+    end)
   end
 end

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -1005,6 +1005,123 @@ defmodule Mimic.Test do
     end
   end
 
+  describe "allow/3 with function allowances" do
+    setup :set_mimic_private
+    setup :verify_on_exit!
+
+    test "shares mocks with a process whose pid is discovered lazily" do
+      parent_pid = self()
+      name = :"lazy_calc_#{System.unique_integer([:positive])}"
+
+      Calculator
+      |> expect(:add, fn x, y -> x + y + 100 end)
+      |> allow(self(), fn -> Process.whereis(name) end)
+
+      spawn_link(fn ->
+        Process.register(self(), name)
+        result = Calculator.add(1, 2)
+        send(parent_pid, {:result, result})
+      end)
+
+      assert_receive {:result, 103}
+    end
+
+    test "lazy function is called on each mock invocation" do
+      parent_pid = self()
+      name = :"lazy_cache_#{System.unique_integer([:positive])}"
+      counter = :counters.new(1, [:atomics])
+
+      Calculator
+      |> expect(:add, 2, fn x, y -> x + y + 100 end)
+      |> allow(self(), fn ->
+        :counters.add(counter, 1, 1)
+        Process.whereis(name)
+      end)
+
+      spawn_link(fn ->
+        Process.register(self(), name)
+        Calculator.add(1, 2)
+        Calculator.add(3, 4)
+        send(parent_pid, :done)
+      end)
+
+      assert_receive :done
+      assert :counters.get(counter, 1) == 2
+    end
+
+    test "supports lazy allowances that return a list of pids" do
+      parent_pid = self()
+      name = :"lazy_list_#{System.unique_integer([:positive])}"
+
+      Calculator
+      |> expect(:add, fn x, y -> x + y + 200 end)
+      |> allow(self(), fn -> [Process.whereis(name)] end)
+
+      spawn_link(fn ->
+        Process.register(self(), name)
+        result = Calculator.add(5, 6)
+        send(parent_pid, {:result, result})
+      end)
+
+      assert_receive {:result, 211}
+    end
+
+    test "falls through to original when lazy function returns nil" do
+      allow(Calculator, self(), fn -> nil end)
+      assert Calculator.add(2, 3) == 5
+    end
+
+    test "supports stubs" do
+      parent_pid = self()
+      name = :"lazy_stub_#{System.unique_integer([:positive])}"
+
+      Calculator
+      |> stub(:add, fn x, y -> x * y end)
+      |> allow(self(), fn -> Process.whereis(name) end)
+
+      spawn_link(fn ->
+        Process.register(self(), name)
+        result = Calculator.add(3, 4)
+        send(parent_pid, {:result, result})
+      end)
+
+      assert_receive {:result, 12}
+    end
+
+    test "cleans up lazy allowances when owner process dies" do
+      parent_pid = self()
+      name = :"lazy_cleanup_#{System.unique_integer([:positive])}"
+
+      owner_pid =
+        spawn(fn ->
+          Calculator
+          |> stub(:add, fn _, _ -> 999 end)
+          |> allow(self(), fn -> Process.whereis(name) end)
+        end)
+
+      Process.monitor(owner_pid)
+      assert_receive {:DOWN, _, _, ^owner_pid, _}
+
+      :timer.sleep(1)
+
+      # After owner dies, lazy allowance should be gone — calls fall through to original
+      spawn_link(fn ->
+        Process.register(self(), name)
+        send(parent_pid, {:result, Calculator.add(1, 3)})
+      end)
+
+      assert_receive {:result, 4}
+    end
+
+    test "raises if you try to allow with function while in global mode" do
+      set_mimic_global()
+
+      assert_raise ArgumentError, "Allow must not be called when mode is global.", fn ->
+        allow(Calculator, self(), fn -> self() end)
+      end
+    end
+  end
+
   describe "mode/0 global mode" do
     setup :set_mimic_global
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -28,7 +28,7 @@ ExUnit.start()
 defmodule MyTest do
   use ExUnit.Case, async: true
   use Mimic  # or use Mimic.DSL
-  
+
   # tests here
 end
 ```
@@ -49,7 +49,7 @@ Calculator
 |> expect(:add, fn x, y -> x + y end)
 
 # Multiple calls expectation
-Calculator  
+Calculator
 |> expect(:add, 3, fn x, y -> x + y end)
 
 # Chaining expectations (FIFO order)
@@ -111,7 +111,7 @@ reject(Calculator, :dangerous_operation, 1)
 setup :set_mimic_private
 setup :verify_on_exit!
 
-# Global mode (when needed)  
+# Global mode (when needed)
 setup :set_mimic_global
 # Remember: async: false required
 ```
@@ -139,9 +139,9 @@ end
 ```elixir
 test "multi-process test" do
   Calculator |> expect(:add, fn x, y -> x + y end)
-  
+
   parent_pid = self()
-  
+
   spawn_link(fn ->
     Calculator |> allow(parent_pid, self())
     assert Calculator.add(1, 2) == 3
@@ -149,7 +149,52 @@ test "multi-process test" do
 end
 ```
 
-### **IMPORTANT**: Task Automatic Allowance  
+### Using `allow/3` with Lazy (Deferred) Allowances
+
+When the process you want to allow doesn't exist yet at the time you set up
+expectations, pass a zero-arity function instead of a pid. The function is
+called on each mock invocation to determine whether the caller is allowed,
+so it handles dynamic process pools where pids change over time.
+
+```elixir
+test "allows a process that starts later" do
+  Calculator
+  |> expect(:add, fn x, y -> x + y end)
+  |> allow(self(), fn -> GenServer.whereis(MyServer) end)
+
+  start_supervised!(MyServer)
+  # MyServer can now call Calculator.add and hit the expectation
+end
+```
+
+**Using with Registry lookup** (recommended for named GenServers):
+
+```elixir
+test "device calls reporter after configure" do
+  id = "device-#{System.unique_integer([:positive])}"
+
+  resolver = fn ->
+    case Registry.lookup(:devices, id) do
+      [{pid, _}] -> pid
+      [] -> nil
+    end
+  end
+
+  expect(GridPoint.Reporter, :report_connectivity, fn ^id, :connected -> :ok end)
+  allow(GridPoint.Reporter, self(), resolver)
+
+  start_supervised!({MyDevice, id: id})
+end
+```
+
+**Key behaviors:**
+
+- Returns `nil` → falls through to the original implementation (no error)
+- Returns a single pid → that pid is allowed
+- Returns a list of pids → all are allowed
+- The function is called on each mock invocation to determine whether the caller is allowed
+
+### **IMPORTANT**: Task Automatic Allowance
 
 - Tasks automatically inherit parent process mocks
 - No need to call `allow/3` for `Task.async`
@@ -183,7 +228,7 @@ Mimic.copy(HTTPClient, type_check: true)
 
 ### Calling Original Implementation
 
-```elixir  
+```elixir
 call_original(Calculator, :add, [1, 2])  # Returns 3
 ```
 
@@ -220,7 +265,7 @@ setup :verify_on_exit!  # Auto-verify expectations
 Calculator
 |> stub(:add, fn _, _ -> :fallback end)      # Fallback after expectations
 |> expect(:add, fn _, _ -> :first end)       # First call
-|> expect(:add, fn _, _ -> :second end)      # Second call  
+|> expect(:add, fn _, _ -> :second end)      # Second call
 # Third call returns :fallback
 ```
 


### PR DESCRIPTION
This PR adds Lazy Allowances like what's [possible in Mox](https://mox.hexdocs.pm/Mox.html#module-explicit-allowances).

In some cases, it's not possible to know the `pid` of the Process you need to share stubs or expectations with at the time of the allowance. This lets Mimic check if the stubs/expectations should be shared at the time the mocked function is called.

Because the lazy functions need to be stored in a GenServer, this represents something of a performance hit for those cases. In order to avoid calling the GenServer unnecessarily, this caches (in ETS) a list of modules with any lazy allowances registered. Any modules with lazy allowances will take that slight hit, but modules without lazy allowances will only take the hit of an extra ETS lookup.