### PR TITLE
Fix memory leak from incorrect ETS select clause

### DIFF
--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -205,7 +205,7 @@ defmodule Mimic.Server do
     expectations = Map.delete(state.expectations, pid)
     stubs = Map.delete(state.stubs, pid)
 
-    select = [{{{pid, :_}}, [], [true]}, {{{:_, :_}, pid}, [], [true]}]
+    select = [{{{pid, :_}, :_}, [], [true]}, {{{:_, :_}, pid}, [], [true]}]
 
     :ets.select_delete(@table, select)
 

--- a/test/mimic_test.exs
+++ b/test/mimic_test.exs
@@ -987,6 +987,36 @@ defmodule Mimic.Test do
       assert Calculator.add(1, 1) == 9
     end
 
+    test "removes the allowed pid's own ownership row when the allowed pid dies" do
+      parent_pid = self()
+
+      allowed_pid =
+        spawn(fn ->
+          # Registers this process as an owner (of an unrelated stub) so that
+          # Mimic.Server monitors it directly, independent of the allow row
+          # asserted on below.
+          Calculator |> stub(:mult, fn _, _ -> :unused end)
+          Calculator |> allow(parent_pid, self())
+
+          send(parent_pid, :ready)
+
+          receive do
+            :done -> :ok
+          end
+        end)
+
+      assert_receive :ready
+      assert :ets.lookup(Mimic.Coordinator, {allowed_pid, Calculator}) != []
+
+      ref = Process.monitor(allowed_pid)
+      send(allowed_pid, :done)
+      assert_receive {:DOWN, ^ref, :process, ^allowed_pid, :normal}
+
+      :timer.sleep(1)
+
+      assert :ets.lookup(Mimic.Coordinator, {allowed_pid, Calculator}) == []
+    end
+
     test "raises if you try to allow process while in global mode" do
       set_mimic_global()
       parent_pid = self()


### PR DESCRIPTION
The first `select_delete` clause was using a 1-tuple, but rows in the shared ownership table are always 2-tuples in the form `{{allowed_pid, module}, owner_pid})`. Therefore the first clause just silently never matched anything.

Only rows where the dying pid was the owner (stored as the value) were ever cleaned up. Rows where the dying pid was the allowed party (stored as the key) leaked in the table for the life of the VM.