### PR TITLE
Fix exit/teardown race condition

### DIFF
--- a/lib/mimic/coordinator.ex
+++ b/lib/mimic/coordinator.ex
@@ -41,8 +41,16 @@ defmodule Mimic.Coordinator do
     GenServer.call(__MODULE__, {:allow, module, owner_pid, allowed_pid}, @long_timeout)
   end
 
+  # Blocks until global mode is actually released, so test teardown can wait for
+  # it. Must not be called from inside a Mimic.Server shard: `soft_reset` calls
+  # into every shard, so a shard blocking on the Coordinator can deadlock.
   @spec clear_global_owner(pid) :: :ok
   def clear_global_owner(pid) do
+    GenServer.call(__MODULE__, {:clear_global_owner, pid}, @long_timeout)
+  end
+
+  @spec clear_global_owner_async(pid) :: :ok
+  def clear_global_owner_async(pid) do
     GenServer.cast(__MODULE__, {:clear_global_owner, pid})
   end
 
@@ -107,6 +115,11 @@ defmodule Mimic.Coordinator do
 
   def handle_call({:set_global_mode, owner_pid}, _from, state) do
     :ets.insert(@table, {:mode, :global, owner_pid})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:clear_global_owner, pid}, _from, state) do
+    release_global_mode(pid)
     {:reply, :ok, state}
   end
 
@@ -214,12 +227,15 @@ defmodule Mimic.Coordinator do
   end
 
   def handle_cast({:clear_global_owner, pid}, state) do
+    release_global_mode(pid)
+    {:noreply, state}
+  end
+
+  defp release_global_mode(pid) do
     case :ets.lookup(@table, :mode) do
       [{:mode, :global, ^pid}] -> :ets.insert(@table, {:mode, :private})
       _ -> :ok
     end
-
-    {:noreply, state}
   end
 
   # Reset task has successfully finished

--- a/lib/mimic/server.ex
+++ b/lib/mimic/server.ex
@@ -74,9 +74,22 @@ defmodule Mimic.Server do
     end
   end
 
+  # Synchronous on purpose: this runs from the `on_exit` callback registered by
+  # `verify_on_exit!`, which is the last thing ExUnit waits for before starting the next test.
+  # Avoids f.ex. global mode to leak into subsequent tests.
   @spec exit(pid) :: :ok
   def exit(pid) do
-    GenServer.cast(shard(pid), {:exit, pid})
+    :ok = GenServer.call(shard(pid), {:exit, pid}, @long_timeout)
+
+    # Only global owners need the extra round trip, so private mode teardowns
+    # don't serialize on the suite-wide `Coordinator`
+    if global_owner?(pid), do:  Coordinator.clear_global_owner(pid)
+
+    :ok
+  end
+
+  defp global_owner?(pid) do
+    match?([{:mode, :global, ^pid}], :ets.lookup(@table, :mode))
   end
 
   @spec get_calls(module, atom, arity) ::
@@ -181,15 +194,14 @@ defmodule Mimic.Server do
     {:ok, %State{}}
   end
 
-  def handle_cast({:exit, pid}, state) do
-    {:noreply, clear_data_from_pid(pid, state)}
-  end
-
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     new_state =
       if MapSet.member?(state.verify_on_exit, pid) do
         state
       else
+        # Safety net for owners that exited without going through `exit/1`
+        # Nothing is waiting on this, so releasing global mode can be async
+        Coordinator.clear_global_owner_async(pid)
         clear_data_from_pid(pid, state)
       end
 
@@ -208,8 +220,6 @@ defmodule Mimic.Server do
     select = [{{{pid, :_}, :_}, [], [true]}, {{{:_, :_}, pid}, [], [true]}]
 
     :ets.select_delete(@table, select)
-
-    Coordinator.clear_global_owner(pid)
 
     call_history = Map.delete(state.call_history, pid)
 
@@ -383,6 +393,10 @@ defmodule Mimic.Server do
 
   def handle_call({:verify_on_exit, pid}, _from, state) do
     {:reply, :ok, %{state | verify_on_exit: MapSet.put(state.verify_on_exit, pid)}}
+  end
+
+  def handle_call({:exit, pid}, _from, state) do
+    {:reply, :ok, clear_data_from_pid(pid, state)}
   end
 
   def handle_call(:soft_reset, _from, state) do

--- a/test/mimic/global_teardown_race_test.exs
+++ b/test/mimic/global_teardown_race_test.exs
@@ -1,0 +1,66 @@
+defmodule Mimic.GlobalTeardownRaceTest do
+  use ExUnit.Case, async: false
+
+  # Global mode is released asynchronously: the owning process exiting triggers
+  # a cast to a Mimic.Server shard, which in turn casts
+  # `Coordinator.clear_global_owner/1`. Nothing ExUnit waits on closes that gap, so
+  # the next (private mode) test can still observe {:mode, :global, <dead pid>}.
+  #
+  # Suspending the Coordinator here stands in for "the Coordinator has not been
+  # scheduled yet", which is what CPU contention on a busy CI runner produces.
+
+  setup do
+    on_exit(fn ->
+      :sys.resume(Mimic.Coordinator)
+      Mimic.Coordinator.set_private_mode()
+    end)
+  end
+
+  test "mode is back to private once the global owner's teardown has run" do
+    tear_down_global_owner()
+
+    assert Mimic.Coordinator.get_mode() == :private
+  end
+
+  test "the next test can set expectations once the global owner's teardown has run" do
+    tear_down_global_owner()
+
+    Mimic.expect(Calculator, :add, fn _, _ -> 42 end)
+    assert Calculator.add(1, 2) == 42
+  end
+
+  # Runs a global mode owner, doing everything ExUnit and Mimic
+  # and returns once no further teardown work is synchronised with the test suite.
+  defp tear_down_global_owner do
+    test_pid = self()
+
+    owner =
+      spawn(fn ->
+        Mimic.Server.verify_on_exit(self())
+        Mimic.set_mimic_global(%{})
+        Mimic.stub(Calculator, :add, fn _, _ -> :stubbed end)
+        send(test_pid, :ready)
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    assert_receive :ready
+    assert Mimic.Coordinator.get_mode() == :global
+
+    # suspended to "mimic" a busy system
+    :sys.suspend(Mimic.Coordinator)
+
+    ref = Process.monitor(owner)
+    send(owner, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^owner, :normal}
+
+    # What Mimic's own `verify_on_exit!` on_exit callback does.
+    # ExUnit waits for that callback to return before starting the next test.
+    Mimic.Server.exit(owner)
+
+    # Make sure the shard's mailbox is empty: once this call is answered the shard has
+    # handled {:exit, owner} and has already cast `clear_global_owner/1`.
+    assert Mimic.Server.verify(owner) == []
+  end
+end

--- a/test/mimic/global_teardown_race_test.exs
+++ b/test/mimic/global_teardown_race_test.exs
@@ -1,12 +1,13 @@
-defmodule Mimic.GlobalTeardownRaceTest do
+defmodule Mimic.GlobalTeardownTest do
   use ExUnit.Case, async: false
 
-  # Global mode is released asynchronously: the owning process exiting triggers
-  # a cast to a Mimic.Server shard, which in turn casts
-  # `Coordinator.clear_global_owner/1`. Nothing ExUnit waits on closes that gap, so
-  # the next (private mode) test can still observe {:mode, :global, <dead pid>}.
+  # Releasing global mode has to be synchronous with the `on_exit` callback
+  # `verify_on_exit!` registers, because that callback is the last thing ExUnit
+  # waits for before starting the next test. If any part of it is a cast, the
+  # next (private mode) test can still observe {:mode, :global, <finished test
+  # pid>} and blow up with "Expect cannot be called by the current process."
   #
-  # Suspending the Coordinator here stands in for "the Coordinator has not been
+  # Suspending the Coordinator stands in for "the Coordinator has not been
   # scheduled yet", which is what CPU contention on a busy CI runner produces.
 
   setup do
@@ -16,22 +17,38 @@ defmodule Mimic.GlobalTeardownRaceTest do
     end)
   end
 
-  test "mode is back to private once the global owner's teardown has run" do
-    tear_down_global_owner()
+  test "Server.exit/1 does not return before global mode is released" do
+    owner = start_global_owner()
+    stop(owner)
+
+    # Busy system: the Coordinator does not get scheduled for a while.
+    :sys.suspend(Mimic.Coordinator)
+
+    # What `verify_on_exit!`'s on_exit callback does (mimic.ex).
+    {teardown, teardown_ref} = spawn_monitor(fn -> Mimic.Server.exit(owner) end)
+
+    refute_receive {:DOWN, ^teardown_ref, :process, ^teardown, _},
+                   100,
+                   "Server.exit/1 returned while global mode was still set"
+
+    :sys.resume(Mimic.Coordinator)
+    assert_receive {:DOWN, ^teardown_ref, :process, ^teardown, :normal}
 
     assert Mimic.Coordinator.get_mode() == :private
   end
 
-  test "the next test can set expectations once the global owner's teardown has run" do
-    tear_down_global_owner()
+  test "the next test can set expectations once the owner's teardown has run" do
+    owner = start_global_owner()
+    stop(owner)
+    Mimic.Server.exit(owner)
 
     Mimic.expect(Calculator, :add, fn _, _ -> 42 end)
     assert Calculator.add(1, 2) == 42
   end
 
-  # Runs a global mode owner, doing everything ExUnit and Mimic
-  # and returns once no further teardown work is synchronised with the test suite.
-  defp tear_down_global_owner do
+  # A global mode test process, set up the way `use Mimic` plus
+  # `setup :set_mimic_from_context` set up an `async: false` case.
+  defp start_global_owner do
     test_pid = self()
 
     owner =
@@ -40,6 +57,7 @@ defmodule Mimic.GlobalTeardownRaceTest do
         Mimic.set_mimic_global(%{})
         Mimic.stub(Calculator, :add, fn _, _ -> :stubbed end)
         send(test_pid, :ready)
+
         receive do
           :stop -> :ok
         end
@@ -48,19 +66,12 @@ defmodule Mimic.GlobalTeardownRaceTest do
     assert_receive :ready
     assert Mimic.Coordinator.get_mode() == :global
 
-    # suspended to "mimic" a busy system
-    :sys.suspend(Mimic.Coordinator)
+    owner
+  end
 
+  defp stop(owner) do
     ref = Process.monitor(owner)
     send(owner, :stop)
     assert_receive {:DOWN, ^ref, :process, ^owner, :normal}
-
-    # What Mimic's own `verify_on_exit!` on_exit callback does.
-    # ExUnit waits for that callback to return before starting the next test.
-    Mimic.Server.exit(owner)
-
-    # Make sure the shard's mailbox is empty: once this call is answered the shard has
-    # handled {:exit, owner} and has already cast `clear_global_owner/1`.
-    assert Mimic.Server.verify(owner) == []
   end
 end


### PR DESCRIPTION
👋 

Thank you for your work, I really enjoy mimic 💚 

d6ea3d597bb61f9331fcaf8492ab4e08c70cdcf7 - explains the problem as observed in a realtime test run, adds failing tests illustrating the problem
a521bba6a62333438de51b8260b263d6354b4d28 - fixes it via some sync calls

I don't know this code base well, so I hope it all makes sense.

In essence, `Server.exit/1` was a `cast` and then in turn did another `cast` - which were racing with `ExUnit` launching another test. If `ExUnit` was faster a `private` mode test might still observe `global` mode, hence failing the test.

This converts them to `call` or a direct call where possible (avoiding a deadlock during `soft_reset` which is also a `call`).

Verified my local version against `realtime` - which passed so at least it doesn't break anything catastrophic 😅 